### PR TITLE
Switch chat logs to sqlite storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - `update_messages.py`：负责导出Telegram聊天记录。
 - `main.py`：解析消息并写入数据库，同时生成 HTML 文件所需的数据。
 - `server.py`：从数据库中按需加载聊天记录并支持搜索。
+- `migrate_messages.py`：将旧版 `messages.json` 数据迁移到数据库。
 
 ## 使用方法
 
@@ -32,13 +33,20 @@
 
 运行以下命令导出聊天记录并生成HTML文件：
 ```bash
-python main.py <user_id>
+python main.py <user_id> [--remark 昵称]
 ```
-其中，`<user_id>`是你要生成HTML文件的用户ID。
+其中，`<user_id>`是你要生成HTML文件的用户ID，`--remark` 可为该聊天设置备注名。
 
 如果你已经导出过聊天记录，可以使用`--ne`选项跳过导出步骤：
 ```bash
 python main.py <user_id> --ne
+```
+
+### 迁移旧版 JSON 数据
+
+若之前的版本生成过 `messages.json` 文件，可以使用以下脚本将其迁移到数据库：
+```bash
+python migrate_messages.py <user_id>
 ```
 
 ### 启动服务器查看聊天记录
@@ -62,3 +70,4 @@ BOT_PASSWORD=你的密码 python server.py
 
 - 确保你有权限访问Telegram聊天记录。
 - 聊天记录会存储在`data/<user_id>/messages.db`数据库文件中，生成的HTML文件也会保存在当前目录。
+- 如果使用`--remark`设置备注名，相关信息会保存在`data/<user_id>/info.json`。

--- a/migrate_messages.py
+++ b/migrate_messages.py
@@ -1,0 +1,30 @@
+import os
+import json
+import sys
+from main import save_messages_to_db
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+if len(sys.argv) != 2:
+    print('Usage: python migrate_messages.py <chat_id>')
+    sys.exit(1)
+
+chat_id = sys.argv[1]
+data_dir = os.path.join(script_dir, 'data', chat_id)
+json_path = os.path.join(data_dir, 'messages.json')
+db_path = os.path.join(data_dir, 'messages.db')
+
+if not os.path.exists(json_path):
+    print(f'No messages.json found for {chat_id}')
+    sys.exit(0)
+
+with open(json_path, 'r', encoding='utf-8') as f:
+    messages = json.load(f)
+
+if isinstance(messages, dict):
+    # in case file was stored as {"messages": [...]} like export output
+    messages = messages.get('messages', [])
+
+save_messages_to_db(db_path, chat_id, messages)
+os.remove(json_path)
+print(f'Migrated {len(messages)} messages to {db_path}')

--- a/server.py
+++ b/server.py
@@ -76,10 +76,20 @@ def list_chats():
     data_dir = os.path.join(script_dir, 'data')
     if not os.path.isdir(data_dir):
         return jsonify({'chats': []})
-    chats = [
-        name for name in os.listdir(data_dir)
-        if os.path.isdir(os.path.join(data_dir, name))
-    ]
+    chats = []
+    for name in os.listdir(data_dir):
+        if not os.path.isdir(os.path.join(data_dir, name)):
+            continue
+        remark = None
+        info_file = os.path.join(data_dir, name, 'info.json')
+        if os.path.exists(info_file):
+            try:
+                with open(info_file, 'r', encoding='utf-8') as f:
+                    info = json.load(f)
+                remark = info.get('remark')
+            except Exception as e:
+                logger.error(f'Error reading {info_file}: {e}')
+        chats.append({'id': name, 'remark': remark})
     return jsonify({'chats': chats})
 
 @app.route('/messages/<chat_id>')

--- a/template.html
+++ b/template.html
@@ -674,9 +674,9 @@
                     select.innerHTML = '<option value="">切换聊天</option>';
                     data.chats.forEach(chat => {
                         const opt = document.createElement('option');
-                        opt.value = chat;
-                        opt.textContent = chat;
-                        if (chat === '{{ chat_id }}') opt.selected = true;
+                        opt.value = chat.id;
+                        opt.textContent = chat.remark || chat.id;
+                        if (chat.id === '{{ chat_id }}') opt.selected = true;
                         select.appendChild(opt);
                     });
                 });


### PR DESCRIPTION
## Summary
- store messages in SQLite database instead of JSON
- query chat logs from SQLite in `server.py`
- document new database storage in README

## Testing
- `python -m py_compile main.py server.py update_messages.py`

------
https://chatgpt.com/codex/tasks/task_e_684bf2d01034832cb36f15deaeb693ff