### PR TITLE
Add startup workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ BOT_PASSWORD=你的密码 python server.py
 服务器默认只监听本机的 `127.0.0.1`，并启用基本认证。访问
 `http://localhost:5000/chat/<user_id>` 时浏览器会询问用户名和密码，默
 认用户名为 `user`，密码由 `BOT_PASSWORD` 环境变量指定。
+启动服务器后，也可以访问根地址 `/`，在网页表单中填写聊天 ID、备注，并选择是否下载文件、导出全部消息及原始数据来新增聊天记录。这些设置会保存到 `chats.json`，重启后仍会生效。服务器启动时会自动读取 `chats.json`，并为其中的每个聊天启动后台导出线程。
 
 静态文件会从根路径提供，例如 `http://localhost:5000/resources/bg.png`、
 `http://localhost:5000/fonts/Roboto-Regular.ttf` 和 `/downloads/<user_id>/...`。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>聊天频道管理</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background: #000; color: #fff; }
+        input, button { padding: 6px; margin: 4px; }
+        ul { list-style: none; padding: 0; }
+        li { margin: 5px 0; }
+    </style>
+</head>
+<body>
+    <h1>聊天频道管理</h1>
+    <form id="addForm">
+        <input type="text" id="chatId" placeholder="聊天ID" required />
+        <input type="text" id="remark" placeholder="备注(可选)" />
+        <label><input type="checkbox" id="downloadFiles" checked />下载附件</label>
+        <label><input type="checkbox" id="allMessages" checked />导出全部消息</label>
+        <label><input type="checkbox" id="rawMessages" checked />导出原始数据</label>
+        <button type="submit">添加</button>
+    </form>
+    <ul id="chatList"></ul>
+    <script>
+        function loadChats() {
+            fetch('/chats')
+                .then(r => r.json())
+                .then(data => {
+                    const ul = document.getElementById('chatList');
+                    ul.innerHTML = '';
+                    data.chats.forEach(chat => {
+                        const li = document.createElement('li');
+                        const a = document.createElement('a');
+                        a.href = '/chat/' + encodeURIComponent(chat.id);
+                        a.textContent = chat.remark || chat.id;
+                        li.appendChild(a);
+                        ul.appendChild(li);
+                    });
+                });
+        }
+        document.getElementById('addForm').addEventListener('submit', e => {
+            e.preventDefault();
+            const id = document.getElementById('chatId').value.trim();
+            const remark = document.getElementById('remark').value.trim();
+            const download = document.getElementById('downloadFiles').checked;
+            const allMsg = document.getElementById('allMessages').checked;
+            const rawMsg = document.getElementById('rawMessages').checked;
+            if (!id) return;
+            fetch('/add_chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    chat_id: id,
+                    remark: remark,
+                    download_files: download,
+                    all_messages: allMsg,
+                    raw_messages: rawMsg
+                })
+            })
+            .then(r => r.json())
+            .then(() => {
+                document.getElementById('chatId').value = '';
+                document.getElementById('remark').value = '';
+                document.getElementById('downloadFiles').checked = true;
+                document.getElementById('allMessages').checked = true;
+                document.getElementById('rawMessages').checked = true;
+                loadChats();
+            });
+        });
+        document.addEventListener('DOMContentLoaded', loadChats);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- start background export workers for chats saved in `chats.json`
- reuse the worker logic when adding chats
- document automatic worker startup in README

## Testing
- `python -m py_compile server.py main.py update_messages.py migrate_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_6872c400cb70832c981f45daee44d2e4