### PR TITLE
Refactor database handling

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -1,0 +1,96 @@
+import os
+import sqlite3
+import json
+import re
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+def get_db_path(chat_id):
+    data_dir = os.path.join(script_dir, 'data', chat_id)
+    if not os.path.exists(data_dir):
+        os.makedirs(data_dir)
+    return os.path.join(data_dir, 'messages.db')
+
+def init_db(conn):
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS messages(
+            chat_id TEXT,
+            msg_id INTEGER,
+            date TEXT,
+            timestamp INTEGER,
+            msg_file_name TEXT,
+            user TEXT,
+            msg TEXT,
+            display_height INTEGER,
+            display_width INTEGER,
+            og_info TEXT,
+            msg_files TEXT,
+            PRIMARY KEY(chat_id, msg_id)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS meta(
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+    ''')
+    conn.commit()
+
+def get_connection(chat_id, row_factory=None):
+    db_path = get_db_path(chat_id)
+    conn = sqlite3.connect(db_path)
+    if row_factory:
+        conn.row_factory = row_factory
+    init_db(conn)
+    return conn
+
+def save_messages(conn, chat_id, messages):
+    insert_sql = '''
+        INSERT OR IGNORE INTO messages(
+            chat_id, msg_id, date, timestamp,
+            msg_file_name, user, msg,
+            display_height, display_width, og_info, msg_files
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    '''
+    data = []
+    for m in messages:
+        og_info = json.dumps(m.get('og_info'), ensure_ascii=False) if m.get('og_info') else None
+        msg_files = json.dumps(m.get('msg_files'), ensure_ascii=False) if m.get('msg_files') else None
+        data.append((chat_id, m['msg_id'], m['date'], m['timestamp'],
+                     m['msg_file_name'], m['user'], m['msg'],
+                     m['display_height'], m['display_width'], og_info, msg_files))
+    conn.executemany(insert_sql, data)
+    conn.commit()
+
+def get_last_export_time(conn):
+    cur = conn.cursor()
+    cur.execute("SELECT value FROM meta WHERE key='last_export_time'")
+    row = cur.fetchone()
+    return row[0] if row else '0'
+
+def set_last_export_time(conn, value):
+    conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES('last_export_time', ?)", (str(value),))
+    conn.commit()
+
+def update_og_info(conn, chat_id, og_fetcher):
+    cursor = conn.cursor()
+    cursor.execute('SELECT msg_id, msg FROM messages WHERE chat_id = ?', (chat_id,))
+    rows = cursor.fetchall()
+    update_sql = '''
+        UPDATE messages
+        SET og_info = ?
+        WHERE chat_id = ? AND msg_id = ?
+    '''
+    for msg_id, msg in rows:
+        if not msg:
+            continue
+        links = re.findall(r'(https?://\S+)', msg)
+        if not links:
+            continue
+        try:
+            og_info = og_fetcher(links[0])
+            og_info_json = json.dumps(og_info, ensure_ascii=False)
+            cursor.execute(update_sql, (og_info_json, chat_id, msg_id))
+        except Exception:
+            continue
+    conn.commit()

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from db_utils import get_connection, get_db_path
 import sqlite3
 import time
 from threading import Thread
@@ -104,16 +105,12 @@ def downloads_files(filename):
     if not os.path.isfile(full_path):
         abort(404)
     return send_from_directory(os.path.join(script_dir, 'downloads'), filename)
-
 def get_db(chat_id):
-    db_path = os.path.join(script_dir, 'data', chat_id, 'messages.db')
+    db_path = get_db_path(chat_id)
     if not os.path.exists(db_path):
         return None
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
+    conn = get_connection(chat_id, sqlite3.Row)
     return conn
-
-@app.route('/chat/<chat_id>')
 @requires_auth
 def chat_page(chat_id):
     return render_template('template.html', chat_id=chat_id)


### PR DESCRIPTION
## Summary
- centralize DB helpers in `db_utils.py`
- update message export to track last export time in DB
- refactor server and main scripts to use new helpers

## Testing
- `python3 -m py_compile main.py update_messages.py server.py db_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687363227ebc832c8f783b50f27b4598