### PR TITLE
Unify logging across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ BOT_PASSWORD=你的密码 python server.py
 
 ## 日志文件
 
-导出聊天记录的日志会保存在`update_messages.log`文件中，方便排查问题。
+所有操作的日志都会写入`logs/project.log`文件，方便排查问题。
 
 ## 注意事项
 

--- a/project_logger.py
+++ b/project_logger.py
@@ -1,0 +1,25 @@
+import os
+import logging
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+log_dir = os.path.join(script_dir, 'logs')
+os.makedirs(log_dir, exist_ok=True)
+log_file = os.path.join(log_dir, 'project.log')
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(log_file, encoding='utf-8'),
+    ]
+)
+
+class RemarkAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        remark = self.extra.get('remark')
+        prefix = f'[{remark}] ' if remark else ''
+        return prefix + msg, kwargs
+
+def get_logger(remark=None):
+    base_logger = logging.getLogger('telegram_bot')
+    return RemarkAdapter(base_logger, {'remark': remark})

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 import os
 import json
-import logging
+from project_logger import get_logger
 from db_utils import get_connection, get_db_path
 import sqlite3
 import time
@@ -58,8 +58,7 @@ USERNAME = os.environ.get('BOT_USERNAME', 'user')
 PASSWORD = os.environ.get('BOT_PASSWORD')
 
 # 配置日志
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger('server')
 
 def check_auth(auth):
     return auth and auth.username == USERNAME and PASSWORD and auth.password == PASSWORD
@@ -275,9 +274,9 @@ if __name__ == '__main__':
     system = platform.system()
     if system == 'Windows':
         from waitress import serve
-        print(f"Running on http://{host}:{port} (Windows via waitress)")
+        logger.info(f"Running on http://{host}:{port} (Windows via waitress)")
         serve(app, host=host, port=port)
     else:
         # Linux 开发环境（非生产）
-        print(f"Running on http://{host}:{port} (Linux dev mode)")
+        logger.info(f"Running on http://{host}:{port} (Linux dev mode)")
         app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- centralize logging in project_logger
- log with chat remark for context
- update scripts to use new logger
- document new log location

## Testing
- `python -m py_compile project_logger.py update_messages.py main.py server.py db_utils.py migrate_messages.py`

------
https://chatgpt.com/codex/tasks/task_e_687368af9038832c847c1e66aab0c9b5