### PR TITLE
Add worker start API with UI button

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 </head>
 <body>
 <h1>聊天频道管理</h1>
+<button id="startWorkers">启动Workers</button>
 <form id="addForm">
   <input type="number" id="chatId" placeholder="聊天ID" required/>
   <input type="text" id="remark" placeholder="备注(可选)"/>
@@ -95,7 +96,30 @@
                 loadChats();
             });
     });
-    document.addEventListener('DOMContentLoaded', loadChats);
+    function checkWorkers() {
+        fetch('/workers_status')
+            .then(r => r.json())
+            .then(data => {
+                const btn = document.getElementById('startWorkers');
+                if (data.started) {
+                    btn.disabled = true;
+                    btn.textContent = 'Workers 已启动';
+                } else {
+                    btn.disabled = false;
+                    btn.textContent = '启动Workers';
+                }
+            });
+    }
+
+    document.getElementById('startWorkers').addEventListener('click', () => {
+        fetch('/start_workers', {method: 'POST'})
+            .then(() => checkWorkers());
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+        loadChats();
+        checkWorkers();
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow starting chat workers on demand with `/start_workers` API
- expose `/workers_status` API to query worker state
- update the front page to show a button that starts workers and reflects status
- stop automatically starting chat workers when server loads

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687375ca63cc832cb9d464f278af1aa3