### PR TITLE
feat: unify database and add global search scopes

### DIFF
--- a/scripts/migrate_to_unified_db.py
+++ b/scripts/migrate_to_unified_db.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from telegram_bot.db_utils import (  # noqa: E402
+    get_connection,
+    set_exported_time,
+    set_last_export_time,
+    set_workers_status,
+    upsert_chat,
+)
+
+
+def load_chats_json(chats_file: Path) -> list[dict]:
+    if not chats_file.exists():
+        return []
+    with chats_file.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data if isinstance(data, list) else []
+
+
+def load_old_messages(old_db_path: Path) -> list[dict]:
+    conn = sqlite3.connect(str(old_db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM messages ORDER BY timestamp, msg_id").fetchall()
+        messages = []
+        for row in rows:
+            item = dict(row)
+            sender_id = item.get("sender_id")
+            is_self = item.get("is_self")
+            if sender_id is None:
+                sender_id = "" if item.get("user") == "我" else str(item.get("user") or "")
+            if is_self is None:
+                is_self = 1 if item.get("user") == "我" else 0
+            item["sender_id"] = sender_id
+            item["is_self"] = int(is_self)
+            messages.append(item)
+        return messages
+    finally:
+        conn.close()
+
+
+def load_old_meta(old_db_path: Path) -> dict[str, str]:
+    conn = sqlite3.connect(str(old_db_path))
+    try:
+        rows = conn.execute("SELECT key, value FROM meta").fetchall()
+        return {str(key): str(value) for key, value in rows}
+    except sqlite3.Error:
+        return {}
+    finally:
+        conn.close()
+
+
+def iter_old_chat_dbs(data_dir: Path):
+    for child in sorted(data_dir.iterdir() if data_dir.exists() else []):
+        if not child.is_dir():
+            continue
+        old_db = child / "messages.db"
+        if old_db.exists():
+            yield child.name, old_db
+
+
+def main() -> int:
+    chats_file = ROOT / "chats.json"
+    data_dir = ROOT / "data"
+
+    chats = load_chats_json(chats_file)
+    migrated_chats = 0
+    migrated_messages = 0
+
+    app_conn = get_connection("__global__")
+    app_conn.close()
+
+    for chat in chats:
+        conn = get_connection(str(chat.get("id") or chat.get("chat_id") or ""))
+        try:
+            upsert_chat(conn, chat)
+            migrated_chats += 1
+        finally:
+            conn.close()
+
+    for chat_id, old_db in iter_old_chat_dbs(data_dir):
+        messages = load_old_messages(old_db)
+        meta = load_old_meta(old_db)
+        conn = get_connection(chat_id)
+        try:
+            if not any(str(chat.get("id")) == str(chat_id) for chat in chats):
+                upsert_chat(conn, {"id": chat_id, "remark": chat_id})
+                migrated_chats += 1
+            if messages:
+                from telegram_bot.db_utils import save_messages  # noqa: E402
+
+                save_messages(conn, chat_id, messages)
+                migrated_messages += len(messages)
+            if "last_export_time" in meta:
+                set_last_export_time(conn, meta["last_export_time"])
+            if "exported_time" in meta:
+                set_exported_time(conn, meta["exported_time"])
+            if "workers_status" in meta:
+                set_workers_status(conn, meta["workers_status"])
+        finally:
+            conn.close()
+
+    print(f"迁移完成：聊天 {migrated_chats} 个，消息 {migrated_messages} 条")
+    print("目标数据库：data/app.db")
+    print("建议保留原 data/<chat_id>/messages.db 与 chats.json 作为备份，确认无误后再手动清理。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/telegram_bot/db_utils.py
+++ b/src/telegram_bot/db_utils.py
@@ -1,24 +1,43 @@
-import os
-import sqlite3
 import json
 import re
+import sqlite3
+import time
+from pathlib import Path
 
 from .paths import DATA_DIR
 
-def get_db_path(chat_id):
-    data_dir = DATA_DIR / str(chat_id)
-    data_dir.mkdir(parents=True, exist_ok=True)
-    return str(data_dir / 'messages.db')
+APP_DB_PATH = DATA_DIR / "app.db"
+
+
+class AppConnection(sqlite3.Connection):
+    chat_id: str | None = None
+
+
+def get_app_db_path() -> str:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    return str(APP_DB_PATH)
+
+
+def get_db_path(chat_id=None):
+    return get_app_db_path()
+
+
+def _conn_chat_scope(conn: sqlite3.Connection) -> str:
+    return str(getattr(conn, "chat_id", "") or "")
+
 
 def init_db(conn):
-    conn.execute('''
+    conn.execute(
+        '''
         CREATE TABLE IF NOT EXISTS messages(
-            chat_id TEXT,
-            msg_id INTEGER,
+            chat_id TEXT NOT NULL,
+            msg_id INTEGER NOT NULL,
             date TEXT,
             timestamp INTEGER,
             msg_file_name TEXT,
             user TEXT,
+            sender_id TEXT,
+            is_self INTEGER DEFAULT 0,
             msg TEXT,
             ori_height INTEGER,
             ori_width INTEGER,
@@ -30,14 +49,54 @@ def init_db(conn):
             reply_to_top_id INTEGER DEFAULT 0,
             PRIMARY KEY(chat_id, msg_id)
         )
-    ''')
-    conn.execute('''
+    '''
+    )
+    conn.execute(
+        '''
         CREATE TABLE IF NOT EXISTS meta(
-            key TEXT PRIMARY KEY,
-            value TEXT
+            chat_id TEXT NOT NULL DEFAULT '',
+            key TEXT NOT NULL,
+            value TEXT,
+            PRIMARY KEY(chat_id, key)
         )
-    ''')
-    # Lightweight migrations for existing DBs.
+    '''
+    )
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS chats(
+            id TEXT PRIMARY KEY,
+            remark TEXT,
+            username TEXT,
+            download_files INTEGER NOT NULL DEFAULT 1,
+            download_images_only INTEGER NOT NULL DEFAULT 0,
+            all_messages INTEGER NOT NULL DEFAULT 1,
+            raw_messages INTEGER NOT NULL DEFAULT 1,
+            refresh_reactions INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        )
+    '''
+    )
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS search_scopes(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        )
+    '''
+    )
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS search_scope_items(
+            scope_id INTEGER NOT NULL,
+            chat_id TEXT NOT NULL,
+            PRIMARY KEY(scope_id, chat_id)
+        )
+    '''
+    )
+
     try:
         cols = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
         if "replies_num" not in cols:
@@ -46,30 +105,242 @@ def init_db(conn):
         if "reply_to_top_id" not in cols:
             conn.execute("ALTER TABLE messages ADD COLUMN reply_to_top_id INTEGER DEFAULT 0")
             conn.execute("UPDATE messages SET reply_to_top_id=0 WHERE reply_to_top_id IS NULL")
+        if "sender_id" not in cols:
+            conn.execute("ALTER TABLE messages ADD COLUMN sender_id TEXT")
+        if "is_self" not in cols:
+            conn.execute("ALTER TABLE messages ADD COLUMN is_self INTEGER DEFAULT 0")
+            conn.execute("UPDATE messages SET is_self=0 WHERE is_self IS NULL")
     except Exception:
         pass
 
-    # Indexes must be created after migrations (old DBs may miss columns).
     conn.execute('CREATE INDEX IF NOT EXISTS idx_messages_chat_ts_id ON messages(chat_id, timestamp, msg_id)')
     conn.execute('CREATE INDEX IF NOT EXISTS idx_messages_chat_reply_to_msg_id ON messages(chat_id, reply_to_msg_id)')
     conn.execute('CREATE INDEX IF NOT EXISTS idx_messages_chat_reply_to_top_id ON messages(chat_id, reply_to_top_id)')
+    conn.execute('CREATE INDEX IF NOT EXISTS idx_messages_chat_msg ON messages(chat_id, msg)')
+    conn.execute('CREATE INDEX IF NOT EXISTS idx_scope_items_chat_id ON search_scope_items(chat_id)')
     conn.commit()
 
-def get_connection(chat_id, row_factory=None):
-    db_path = get_db_path(chat_id)
-    conn = sqlite3.connect(db_path)
+
+def get_app_connection(row_factory=None, chat_id: str | None = None):
+    db_path = get_app_db_path()
+    conn = sqlite3.connect(db_path, factory=AppConnection)
+    conn.chat_id = str(chat_id or "")
     if row_factory:
         conn.row_factory = row_factory
     init_db(conn)
     return conn
 
+
+def get_connection(chat_id, row_factory=None):
+    return get_app_connection(row_factory=row_factory, chat_id=str(chat_id or ""))
+
+
+def upsert_chat(conn, chat_item: dict):
+    now = int(time.time())
+    chat_id = str(chat_item.get("id") or chat_item.get("chat_id") or "").strip()
+    if not chat_id:
+        raise ValueError("chat id required")
+
+    existing = conn.execute("SELECT created_at FROM chats WHERE id=?", (chat_id,)).fetchone()
+    created_at = existing[0] if existing else now
+    conn.execute(
+        '''
+        INSERT INTO chats(
+            id, remark, username, download_files, download_images_only,
+            all_messages, raw_messages, refresh_reactions, created_at, updated_at
+        ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            remark=excluded.remark,
+            username=excluded.username,
+            download_files=excluded.download_files,
+            download_images_only=excluded.download_images_only,
+            all_messages=excluded.all_messages,
+            raw_messages=excluded.raw_messages,
+            refresh_reactions=excluded.refresh_reactions,
+            updated_at=excluded.updated_at
+        ''',
+        (
+            chat_id,
+            chat_item.get("remark"),
+            chat_item.get("username"),
+            int(bool(chat_item.get("download_files", True))),
+            int(bool(chat_item.get("download_images_only", False))),
+            int(bool(chat_item.get("all_messages", True))),
+            int(bool(chat_item.get("raw_messages", True))),
+            int(bool(chat_item.get("refresh_reactions", False))),
+            created_at,
+            now,
+        ),
+    )
+    conn.commit()
+    return get_chat(conn, chat_id)
+
+
+def get_chat(conn, chat_id: str):
+    cursor = conn.execute("SELECT * FROM chats WHERE id=?", (str(chat_id),))
+    row = cursor.fetchone()
+    if not row:
+        return None
+    if isinstance(row, sqlite3.Row):
+        return _normalize_chat(dict(row))
+    cols = [d[0] for d in cursor.description or []]
+    return _normalize_chat(dict(zip(cols, row)))
+
+
+def _normalize_chat(item: dict) -> dict:
+    item = dict(item)
+    for key in ("download_files", "download_images_only", "all_messages", "raw_messages", "refresh_reactions"):
+        item[key] = bool(item.get(key))
+    return item
+
+
+def list_chats_db(conn) -> list[dict]:
+    rows = conn.execute("SELECT * FROM chats ORDER BY COALESCE(remark, id), id").fetchall()
+    if rows and isinstance(rows[0], sqlite3.Row):
+        return [_normalize_chat(dict(row)) for row in rows]
+    return [_normalize_chat({
+        "id": row[0], "remark": row[1], "username": row[2], "download_files": row[3],
+        "download_images_only": row[4], "all_messages": row[5], "raw_messages": row[6],
+        "refresh_reactions": row[7], "created_at": row[8], "updated_at": row[9]
+    }) for row in rows]
+
+
+def delete_chat(conn, chat_id: str) -> bool:
+    chat_id = str(chat_id or "").strip()
+    if not chat_id:
+        return False
+    before = conn.total_changes
+    conn.execute("DELETE FROM search_scope_items WHERE chat_id=?", (chat_id,))
+    conn.execute("DELETE FROM messages WHERE chat_id=?", (chat_id,))
+    conn.execute("DELETE FROM meta WHERE chat_id=?", (chat_id,))
+    conn.execute("DELETE FROM chats WHERE id=?", (chat_id,))
+    conn.commit()
+    return (conn.total_changes - before) > 0
+
+
+def upsert_search_scope(conn, name: str, chat_ids: list[str], scope_id: int | None = None) -> dict:
+    name = str(name or "").strip()
+    if not name:
+        raise ValueError("scope name required")
+    chat_ids = [str(chat_id).strip() for chat_id in chat_ids if str(chat_id).strip()]
+    now = int(time.time())
+    if scope_id is None:
+        cur = conn.execute(
+            "INSERT INTO search_scopes(name, created_at, updated_at) VALUES(?, ?, ?)",
+            (name, now, now),
+        )
+        scope_id = int(cur.lastrowid)
+    else:
+        current = conn.execute("SELECT id FROM search_scopes WHERE id=?", (int(scope_id),)).fetchone()
+        if not current:
+            raise ValueError("scope not found")
+        conn.execute(
+            "UPDATE search_scopes SET name=?, updated_at=? WHERE id=?",
+            (name, now, int(scope_id)),
+        )
+        conn.execute("DELETE FROM search_scope_items WHERE scope_id=?", (int(scope_id),))
+
+    conn.executemany(
+        "INSERT OR IGNORE INTO search_scope_items(scope_id, chat_id) VALUES(?, ?)",
+        [(int(scope_id), chat_id) for chat_id in chat_ids],
+    )
+    conn.commit()
+    return get_search_scope(conn, int(scope_id))
+
+
+def get_search_scope(conn, scope_id: int) -> dict | None:
+    row = conn.execute("SELECT id, name, created_at, updated_at FROM search_scopes WHERE id=?", (int(scope_id),)).fetchone()
+    if not row:
+        return None
+    if isinstance(row, sqlite3.Row):
+        data = dict(row)
+    else:
+        data = {"id": row[0], "name": row[1], "created_at": row[2], "updated_at": row[3]}
+    items = conn.execute(
+        "SELECT chat_id FROM search_scope_items WHERE scope_id=? ORDER BY chat_id",
+        (int(scope_id),),
+    ).fetchall()
+    data["chat_ids"] = [item[0] if not isinstance(item, sqlite3.Row) else item["chat_id"] for item in items]
+    return data
+
+
+def list_search_scopes(conn) -> list[dict]:
+    rows = conn.execute("SELECT id FROM search_scopes ORDER BY updated_at DESC, id DESC").fetchall()
+    ids = [row[0] if not isinstance(row, sqlite3.Row) else row["id"] for row in rows]
+    return [scope for scope in (get_search_scope(conn, int(scope_id)) for scope_id in ids) if scope]
+
+
+def delete_search_scope(conn, scope_id: int) -> bool:
+    before = conn.total_changes
+    conn.execute("DELETE FROM search_scope_items WHERE scope_id=?", (int(scope_id),))
+    conn.execute("DELETE FROM search_scopes WHERE id=?", (int(scope_id),))
+    conn.commit()
+    return (conn.total_changes - before) > 0
+
+
+def search_messages_global(conn, query: str, chat_ids: list[str] | None = None, offset: int = 0, limit: int = 20):
+    query = (query or "").strip().lower()
+    limit = max(1, min(int(limit), 200))
+    offset = max(int(offset), 0)
+
+    params: list = []
+    where_parts: list[str] = []
+    if chat_ids:
+        chat_ids = [str(chat_id).strip() for chat_id in chat_ids if str(chat_id).strip()]
+        if chat_ids:
+            placeholders = ",".join("?" for _ in chat_ids)
+            where_parts.append(f"m.chat_id IN ({placeholders})")
+            params.extend(chat_ids)
+
+    if query:
+        keywords = [kw for kw in query.split() if kw]
+        fields_or = " OR ".join([
+            "LOWER(COALESCE(m.date, '')) LIKE ?",
+            "LOWER(COALESCE(m.msg, '')) LIKE ?",
+            "LOWER(COALESCE(m.msg_file_name, '')) LIKE ?",
+            "LOWER(COALESCE(c.remark, '')) LIKE ?",
+            "LOWER(COALESCE(c.username, '')) LIKE ?",
+        ])
+        for kw in keywords:
+            neg = kw.startswith("-")
+            kw = kw[1:] if neg else kw
+            kw = kw.strip().lower()
+            if not kw:
+                continue
+            pattern = f"%{kw}%"
+            where_parts.append((f"NOT ({fields_or})" if neg else f"({fields_or})"))
+            params.extend([pattern] * 5)
+
+    where_sql = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+    count_sql = f"SELECT COUNT(*) FROM messages m LEFT JOIN chats c ON c.id = m.chat_id {where_sql}"
+    total = conn.execute(count_sql, tuple(params)).fetchone()[0]
+
+    page_sql = f'''
+        SELECT m.*, c.remark AS chat_remark, c.username AS chat_username
+        FROM messages m
+        LEFT JOIN chats c ON c.id = m.chat_id
+        {where_sql}
+        ORDER BY m.timestamp DESC, m.msg_id DESC
+        LIMIT ? OFFSET ?
+    '''
+    rows = conn.execute(page_sql, (*params, limit, offset)).fetchall()
+    messages = [dict(row) if isinstance(row, sqlite3.Row) else {
+        "chat_id": row[0], "msg_id": row[1], "date": row[2], "timestamp": row[3], "msg_file_name": row[4],
+        "user": row[5], "sender_id": row[6], "is_self": row[7], "msg": row[8], "ori_height": row[9],
+        "ori_width": row[10], "og_info": row[11], "reactions": row[12], "replies_num": row[13],
+        "msg_files": row[14], "reply_to_msg_id": row[15], "reply_to_top_id": row[16], "chat_remark": row[17],
+        "chat_username": row[18],
+    } for row in rows]
+    return {"total": total, "offset": offset, "messages": messages}
+
+
 def save_messages(conn, chat_id, messages):
     insert_sql = '''
         INSERT OR IGNORE INTO messages(
             chat_id, msg_id, date, timestamp,
-            msg_file_name, user, msg,
+            msg_file_name, user, sender_id, is_self, msg,
             ori_height, ori_width, og_info, reactions, replies_num, msg_files, reply_to_msg_id, reply_to_top_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     '''
 
     data = []
@@ -89,6 +360,10 @@ def save_messages(conn, chat_id, messages):
             reply_to_top_id = int(m.get("reply_to_top_id") or 0)
         except Exception:
             reply_to_top_id = 0
+        try:
+            is_self = int(m.get("is_self") or 0)
+        except Exception:
+            is_self = 0
 
         data.append((
             chat_id,
@@ -97,6 +372,8 @@ def save_messages(conn, chat_id, messages):
             m["timestamp"],
             m["msg_file_name"],
             m["user"],
+            m.get("sender_id"),
+            is_self,
             m["msg"],
             m["ori_height"],
             m["ori_width"],
@@ -114,35 +391,45 @@ def save_messages(conn, chat_id, messages):
     conn.commit()
     return inserted
 
-def get_last_export_time(conn):
-    cur = conn.cursor()
-    cur.execute("SELECT value FROM meta WHERE key='last_export_time'")
-    row = cur.fetchone()
+
+def _meta_get(conn, key: str):
+    chat_scope = _conn_chat_scope(conn)
+    row = conn.execute("SELECT value FROM meta WHERE chat_id=? AND key=?", (chat_scope, key)).fetchone()
     return row[0] if row else '0'
+
+
+def _meta_set(conn, key: str, value):
+    chat_scope = _conn_chat_scope(conn)
+    conn.execute(
+        "INSERT OR REPLACE INTO meta(chat_id, key, value) VALUES(?, ?, ?)",
+        (chat_scope, key, str(value)),
+    )
+    conn.commit()
+
+
+def get_last_export_time(conn):
+    return _meta_get(conn, 'last_export_time')
+
 
 def set_last_export_time(conn, value):
-    conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES('last_export_time', ?)", (str(value),))
-    conn.commit()
+    _meta_set(conn, 'last_export_time', value)
+
 
 def get_exported_time(conn):
-    cur = conn.cursor()
-    cur.execute("SELECT value FROM meta WHERE key='exported_time'")
-    row = cur.fetchone()
-    return row[0] if row else '0'
- 
+    return _meta_get(conn, 'exported_time')
+
+
 def set_exported_time(conn, value):
-    conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES('exported_time', ?)", (str(value),))
-    conn.commit()
-    
+    _meta_set(conn, 'exported_time', value)
+
+
 def set_workers_status(conn, status: str):
-    conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES('workers_status', ?)", (str(status),))
-    conn.commit()
+    _meta_set(conn, 'workers_status', status)
+
 
 def get_workers_status(conn) -> str:
-    cur = conn.cursor()
-    cur.execute("SELECT value FROM meta WHERE key='workers_status'")
-    row = cur.fetchone()
-    return row[0] if row else '0'
+    return _meta_get(conn, 'workers_status')
+
 
 def update_og_info(conn, chat_id, og_fetcher):
     cursor = conn.cursor()
@@ -169,12 +456,6 @@ def update_og_info(conn, chat_id, og_fetcher):
 
 
 def update_reactions(conn, chat_id: str, reactions_by_msg_id: list[tuple[int, dict | None]]) -> int:
-    """
-    Update reactions for existing messages.
-
-    reactions_by_msg_id items are (msg_id, reactions_obj). When reactions_obj is None / empty,
-    reactions is set to NULL.
-    """
     if not reactions_by_msg_id:
         return 0
 

--- a/src/telegram_bot/message_utils.py
+++ b/src/telegram_bot/message_utils.py
@@ -125,7 +125,15 @@ def parse_messages(chat_id: str, raw_messages: List[dict], tz, remark: str | Non
         except Exception:
             replies_num = 0
         reactions = raw_data.get('Reactions') or {}
-        user = '我' if user_id == me_id else user_id
+        out_flag = raw_data.get('Out')
+        if out_flag is None:
+            out_flag = raw_data.get('out')
+        try:
+            is_self = 1 if bool(out_flag) or (user_id and user_id == me_id) else 0
+        except Exception:
+            is_self = 1 if (user_id and user_id == me_id) else 0
+        sender_id = str(user_id or '')
+        user = '我' if is_self else sender_id
 
         message = {
             'date': date,
@@ -134,6 +142,8 @@ def parse_messages(chat_id: str, raw_messages: List[dict], tz, remark: str | Non
             'msg_file_name': msg_file_name,
             'msg_files': [],
             'user': user,
+            'sender_id': sender_id,
+            'is_self': is_self,
             'msg': msg_text,
             'reply_to_msg_id': reply_to_msg_id,
             'reply_to_top_id': reply_to_top_id,

--- a/src/telegram_bot/web_server.py
+++ b/src/telegram_bot/web_server.py
@@ -685,6 +685,12 @@ def chat_page(chat_id: str, request: Request):
     return templates.TemplateResponse("template.html", {"request": request, "chat_id": chat_id, 'chat_username': chat_username})
 
 
+@app.get("/sw.js")
+def service_worker_file():
+    sw_path = STATIC_DIR / "sw.js"
+    return FileResponse(str(sw_path), media_type="application/javascript", headers={"Service-Worker-Allowed": "/", "Cache-Control": "no-cache"})
+
+
 @app.get("/workers_status")
 def workers_status_route():
     return {"started": workers_started()}

--- a/src/telegram_bot/web_server.py
+++ b/src/telegram_bot/web_server.py
@@ -20,7 +20,18 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from telegram_bot.archiver import handle
-from telegram_bot.db_utils import get_connection, get_db_path
+from telegram_bot.db_utils import (
+    delete_chat as delete_chat_record,
+    get_app_connection,
+    get_chat,
+    get_connection,
+    get_db_path,
+    list_chats_db,
+    list_search_scopes,
+    search_messages_global,
+    upsert_chat,
+    upsert_search_scope,
+)
 from telegram_bot.message_utils import is_ali_link_stale, is_quark_link_stale
 from telegram_bot.paths import BASE_DIR, DOWNLOADS_DIR, STATIC_DIR, TEMPLATES_DIR, ensure_runtime_dirs
 from telegram_bot.project_logger import get_logger
@@ -103,6 +114,12 @@ class DownloadMissingImagesRequest(BaseModel):
     batch_size: int = 10
 
 
+class SearchScopeRequest(BaseModel):
+    name: str
+    chat_ids: list[str]
+    scope_id: int | None = None
+
+
 def _json_error(status_code: int, message: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content={"error": message})
 
@@ -112,22 +129,30 @@ def workers_started() -> bool:
 
 
 def load_chats() -> list[dict]:
-    if os.path.exists(CHATS_FILE):
-        try:
+    conn = get_app_connection(row_factory=sqlite3.Row)
+    try:
+        chats = list_chats_db(conn)
+        if chats:
+            return chats
+        if os.path.exists(CHATS_FILE):
             with open(CHATS_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                return data if isinstance(data, list) else []
-        except Exception as e:
-            logger.error(f"Error reading {CHATS_FILE}: {e}")
-    return []
+            if isinstance(data, list):
+                for chat in data:
+                    upsert_chat(conn, chat)
+                return list_chats_db(conn)
+        return []
+    finally:
+        conn.close()
 
 
 def save_chats(chats: list[dict]) -> None:
+    conn = get_app_connection(row_factory=sqlite3.Row)
     try:
-        with open(CHATS_FILE, "w", encoding="utf-8") as f:
-            json.dump(chats, f, ensure_ascii=False, indent=2)
-    except Exception as e:
-        logger.error(f"Error writing {CHATS_FILE}: {e}")
+        for chat in chats:
+            upsert_chat(conn, chat)
+    finally:
+        conn.close()
 
 
 def start_chat_worker(chat: dict, interval: int = 1800) -> None:
@@ -285,6 +310,16 @@ def row_to_message(row):
         item["reply_to_top_id"] = int(item["reply_to_top_id"] or 0)
     except Exception:
         item["reply_to_top_id"] = 0
+    if item.get("is_self") is None:
+        item["is_self"] = 0
+    try:
+        item["is_self"] = int(item.get("is_self") or 0)
+    except Exception:
+        item["is_self"] = 0
+    if item.get("sender_id") is None:
+        item["sender_id"] = ""
+    if item.get("user") in (None, "") and item.get("sender_id"):
+        item["user"] = "我" if item["is_self"] else item["sender_id"]
     return item
 
 
@@ -706,6 +741,49 @@ def list_chats():
     return {"chats": load_chats()}
 
 
+@app.get("/search_scopes")
+def get_search_scopes():
+    conn = get_app_connection(row_factory=sqlite3.Row)
+    try:
+        return {"scopes": list_search_scopes(conn)}
+    finally:
+        conn.close()
+
+
+@app.post("/search_scopes")
+def save_search_scope(payload: SearchScopeRequest):
+    conn = get_app_connection(row_factory=sqlite3.Row)
+    try:
+        scope = upsert_search_scope(conn, payload.name, payload.chat_ids, payload.scope_id)
+        return {"scope": scope}
+    except ValueError as e:
+        return _json_error(400, str(e))
+    finally:
+        conn.close()
+
+
+@app.get("/search_global")
+def global_search_messages(
+    q: str = Query(""),
+    chat_ids: str = Query(""),
+    scope_id: int | None = Query(None),
+    offset: int = Query(0),
+    limit: int = Query(20),
+):
+    conn = get_app_connection(row_factory=sqlite3.Row)
+    try:
+        selected_chat_ids = [c.strip() for c in str(chat_ids or "").split(",") if c.strip()]
+        if scope_id is not None and not selected_chat_ids:
+            scope_rows = conn.execute(
+                "SELECT chat_id FROM search_scope_items WHERE scope_id=? ORDER BY chat_id",
+                (int(scope_id),),
+            ).fetchall()
+            selected_chat_ids = [row["chat_id"] for row in scope_rows]
+        return search_messages_global(conn, q, selected_chat_ids, offset, limit)
+    finally:
+        conn.close()
+
+
 @app.post("/update_chat_settings")
 def update_chat_settings(payload: UpdateChatSettingsRequest):
     chat_id = str(payload.chat_id or "").strip()
@@ -884,14 +962,17 @@ def delete_chat(payload: ChatIdRequest):
 
     chats = load_chats()
     before = len(chats)
-    chats = [c for c in chats if str(c.get("id")) != chat_id]
-    save_chats(chats)
+    deleted = False
+    conn = get_app_connection(row_factory=sqlite3.Row)
+    try:
+        deleted = delete_chat_record(conn, chat_id)
+    finally:
+        conn.close()
 
     removed_data = _safe_remove_tree(str(BASE_DIR / "data"), chat_id)
     removed_downloads = _safe_remove_tree(str(BASE_DIR / "downloads"), chat_id)
 
-    deleted = len(chats) != before
-    return {"deleted": deleted, "removed_data": removed_data, "removed_downloads": removed_downloads}
+    return {"deleted": deleted or (before != len(load_chats())), "removed_data": removed_data, "removed_downloads": removed_downloads}
 
 
 @app.post("/download_telegram_media")
@@ -1267,6 +1348,8 @@ def get_messages(
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1282,6 +1365,8 @@ def get_messages(
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,
@@ -1365,6 +1450,8 @@ def get_messages_between(
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1380,6 +1467,8 @@ def get_messages_between(
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,
@@ -1440,6 +1529,8 @@ def get_message(chat_id: str, msg_id: int):
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1455,6 +1546,8 @@ def get_message(chat_id: str, msg_id: int):
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,
@@ -1524,6 +1617,8 @@ def get_replies(
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1539,6 +1634,8 @@ def get_replies(
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,
@@ -1737,6 +1834,8 @@ def get_messages_by_replies_num(
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1752,6 +1851,8 @@ def get_messages_by_replies_num(
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,
@@ -1858,6 +1959,8 @@ def search_messages(
                 m.timestamp,
                 m.msg_file_name,
                 m.user,
+                m.sender_id,
+                m.is_self,
                 m.msg,
                 m.ori_height,
                 m.ori_width,
@@ -1873,6 +1976,8 @@ def search_messages(
                 r.timestamp AS r_timestamp,
                 r.msg_file_name AS r_msg_file_name,
                 r.user AS r_user,
+                r.sender_id AS r_sender_id,
+                r.is_self AS r_is_self,
                 r.msg AS r_msg,
                 r.ori_height AS r_ori_height,
                 r.ori_width AS r_ori_width,

--- a/src/test/test_unified_db.py
+++ b/src/test/test_unified_db.py
@@ -1,0 +1,137 @@
+import sqlite3
+
+from telegram_bot import db_utils, message_utils
+
+
+def test_parse_messages_sets_sender_id_and_is_self(monkeypatch):
+    monkeypatch.setattr(message_utils, "filter_messages", lambda items: items)
+    monkeypatch.setattr(message_utils, "load_me_id", lambda: "42")
+
+    raw_messages = [
+        {
+            "id": 1,
+            "text": "hello",
+            "date": 1710000000,
+            "raw": {"FromID": {"UserID": "42"}},
+        },
+        {
+            "id": 2,
+            "text": "world",
+            "date": 1710000001,
+            "raw": {"FromID": {"UserID": "99"}},
+        },
+    ]
+
+    messages = message_utils.parse_messages("chat-a", raw_messages, tz=None, remark="test")
+
+    assert messages[0]["sender_id"] == "42"
+    assert messages[0]["is_self"] == 1
+    assert messages[0]["user"] == "我"
+
+    assert messages[1]["sender_id"] == "99"
+    assert messages[1]["is_self"] == 0
+    assert messages[1]["user"] == "99"
+
+
+def test_init_app_db_creates_unified_tables(tmp_path, monkeypatch):
+    app_db = tmp_path / "app.db"
+    monkeypatch.setattr(db_utils, "APP_DB_PATH", app_db)
+
+    conn = db_utils.get_app_connection()
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert {"chats", "messages", "search_scopes", "search_scope_items", "meta"}.issubset(tables)
+
+
+def test_unified_chat_scope_and_global_search(tmp_path, monkeypatch):
+    app_db = tmp_path / "app.db"
+    monkeypatch.setattr(db_utils, "APP_DB_PATH", app_db)
+
+    conn = db_utils.get_app_connection(row_factory=sqlite3.Row)
+    try:
+        db_utils.upsert_chat(conn, {"id": "chat-1", "remark": "频道一", "username": "chan1"})
+        db_utils.upsert_chat(conn, {"id": "chat-2", "remark": "频道二", "username": "chan2"})
+
+        db_utils.save_messages(
+            conn,
+            "chat-1",
+            [
+                {
+                    "msg_id": 1,
+                    "date": "2024-01-01 00:00:00",
+                    "timestamp": 1,
+                    "msg_file_name": "",
+                    "msg_files": [],
+                    "user": "我",
+                    "sender_id": "42",
+                    "is_self": 1,
+                    "msg": "alpha keyword",
+                    "reply_to_msg_id": 0,
+                    "reply_to_top_id": 0,
+                    "replies_num": 0,
+                    "reactions": {},
+                    "ori_height": None,
+                    "ori_width": None,
+                    "og_info": None,
+                }
+            ],
+        )
+        db_utils.save_messages(
+            conn,
+            "chat-2",
+            [
+                {
+                    "msg_id": 2,
+                    "date": "2024-01-01 00:00:01",
+                    "timestamp": 2,
+                    "msg_file_name": "",
+                    "msg_files": [],
+                    "user": "对方",
+                    "sender_id": "99",
+                    "is_self": 0,
+                    "msg": "beta keyword",
+                    "reply_to_msg_id": 0,
+                    "reply_to_top_id": 0,
+                    "replies_num": 0,
+                    "reactions": {},
+                    "ori_height": None,
+                    "ori_width": None,
+                    "og_info": None,
+                }
+            ],
+        )
+
+        scope = db_utils.upsert_search_scope(conn, name="常用范围", chat_ids=["chat-2"])
+        scopes = db_utils.list_search_scopes(conn)
+        result = db_utils.search_messages_global(conn, query="keyword", chat_ids=["chat-2"], offset=0, limit=20)
+    finally:
+        conn.close()
+
+    assert any(item["name"] == "常用范围" for item in scopes)
+    assert scope["chat_ids"] == ["chat-2"]
+    assert result["total"] == 1
+    assert result["messages"][0]["chat_id"] == "chat-2"
+    assert result["messages"][0]["chat_remark"] == "频道二"
+
+
+def test_upsert_search_scope_rejects_missing_scope_id(tmp_path, monkeypatch):
+    app_db = tmp_path / "app.db"
+    monkeypatch.setattr(db_utils, "APP_DB_PATH", app_db)
+
+    conn = db_utils.get_app_connection(row_factory=sqlite3.Row)
+    try:
+        try:
+            db_utils.upsert_search_scope(conn, name="不存在", chat_ids=["chat-1"], scope_id=999)
+            raised = False
+        except ValueError:
+            raised = True
+    finally:
+        conn.close()
+
+    assert raised is True

--- a/src/test/test_web_server.py
+++ b/src/test/test_web_server.py
@@ -1,17 +1,15 @@
-from telegram_bot.web_server import CleanupLinksRequest, _cleanup_link_provider
-from bdpan import BaiduPanConfig, BaiduPanClient
+from telegram_bot.web_server import _cleanup_link_provider
 
-providers = ['ali',  'baidu', 'quark', 'xunlei']
+
+class _FakeBdPan:
+    def is_share_link(self, link: str) -> bool:
+        return "pan.baidu.com" in link
+
+
+providers = ['ali', 'baidu', 'quark', 'xunlei']
 links = ['https://www.aliyundrive.com/s/N8aXBido1v1']
 
-# def test_person(sample_data):
-#     payload = CleanupLinksRequest(
-#         chat_id='123', providers=['ali',  'baidu', 'quark', 'xunlei']
-#     )
-#     assert sample_data["name"] == "Alice"
-#     assert sample_data["age"] == 25
 
 def test_cleanup_link_provider_works():
-    bdpan = BaiduPanClient(config=BaiduPanConfig(cookie_file="auth/cookies.txt"))
+    bdpan = _FakeBdPan()
     assert 'ali' == _cleanup_link_provider(links[0], set(providers), bdpan=bdpan)
-    

--- a/static/chat.css
+++ b/static/chat.css
@@ -614,8 +614,8 @@ body {
 
 @media screen and (max-width: 768px) {
     body {
-        font-size: 17px;
-        font-weight: bold;
+        font-size: 16px;
+        font-weight: 500;
     }
 
     body #header {
@@ -624,26 +624,177 @@ body {
 
     body #searchBox {
         font-size: 14px;
-        width: 150px;
-        margin-left: 8px;
+        width: 100%;
+        margin-left: 0;
     }
 
-    body #confirmSearch {
+    body #confirmSearch,
+    body #downloadBrokenImages,
+    body #exitReplies,
+    body .header-secondary {
         height: 38px;
-        width: 81px;
-        font-size: 10px;
+        min-width: 88px;
+        font-size: 12px;
         line-height: 38px;
+        margin-left: 0;
     }
 
     body .date {
         font-size: 12px;
     }
 
-
-
     .select-component {
-        min-width: 60px;
-        font-size: 10px;
-        margin-left: 5px;
+        min-width: 120px;
+        font-size: 12px;
+        margin-left: 0;
+    }
+
+    .header-main,
+    .header-actions {
+        width: 100%;
+    }
+
+    .scroll-button {
+        right: 14px;
+    }
+}
+
+:root {
+    --app-bg: #020617;
+    --panel-bg: rgba(15, 23, 42, 0.76);
+    --panel-border: rgba(148, 163, 184, 0.18);
+    --panel-shadow: 0 24px 50px -30px rgba(15, 23, 42, 0.9);
+    --control-bg: rgba(15, 23, 42, 0.82);
+    --control-border: rgba(148, 163, 184, 0.2);
+    --control-hover: rgba(30, 41, 59, 0.96);
+    --accent-cyan: #38bdf8;
+    --accent-violet: #8b5cf6;
+}
+
+body {
+    color: #e2e8f0;
+    background-color: var(--app-bg);
+    background-image:
+      radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 32%),
+      radial-gradient(circle at bottom right, rgba(139, 92, 246, 0.16), transparent 28%),
+      linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.98));
+    padding-bottom: max(16px, env(safe-area-inset-bottom));
+}
+
+.container {
+    width: min(1120px, calc(100% - 24px));
+    padding-top: 18px;
+}
+
+#header {
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(1120px, calc(100% - 24px));
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px;
+    background: rgba(2, 6, 23, 0.78);
+    border: 1px solid var(--panel-border);
+    border-radius: 22px;
+    backdrop-filter: blur(18px);
+    box-shadow: var(--panel-shadow);
+    top: max(10px, env(safe-area-inset-top));
+}
+
+.header-main,
+.header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+#searchBox,
+.select-component {
+    background: var(--control-bg);
+    border: 1px solid var(--control-border);
+    color: #f8fafc;
+    min-height: 42px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+}
+
+#searchBox {
+    width: min(360px, 100%);
+    padding: 11px 14px;
+}
+
+#searchBox::placeholder {
+    color: rgba(226, 232, 240, 0.52);
+}
+
+#confirmSearch,
+#downloadBrokenImages,
+#exitReplies,
+.header-secondary {
+    margin-left: 0;
+    min-height: 42px;
+    padding: 0 16px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(14, 165, 233, 0.25));
+    border: 1px solid rgba(56, 189, 248, 0.22);
+    color: #f8fafc;
+    width: auto;
+}
+
+.header-secondary {
+    background: rgba(15, 23, 42, 0.88);
+    border-color: rgba(148, 163, 184, 0.2);
+}
+
+#confirmSearch:hover,
+#downloadBrokenImages:hover,
+#exitReplies:hover,
+.header-secondary:hover,
+.select-component:hover {
+    background: var(--control-hover);
+}
+
+#messages {
+    padding: 108px 0 72px 0;
+}
+
+.top-loader {
+    top: 96px;
+}
+
+.top-loader__inner {
+    background: rgba(15, 23, 42, 0.82);
+    border-color: rgba(148, 163, 184, 0.18);
+}
+
+.scroll-button {
+    background-color: rgba(15, 23, 42, 0.86);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 12px 30px -20px rgba(0,0,0,0.75);
+}
+
+.scroll-button:hover {
+    background-color: rgba(30, 41, 59, 0.96);
+}
+
+.message.has-image .message-row {
+    min-width: min(520px, 60vw);
+}
+
+@media screen and (max-width: 900px) {
+    .container,
+    #header {
+        width: calc(100% - 16px);
+    }
+
+    #messages {
+        padding-top: 132px;
+    }
+
+    .top-loader {
+        top: 120px;
     }
 }

--- a/static/components/message/index.js
+++ b/static/components/message/index.js
@@ -190,7 +190,7 @@ function _linkifyHtml(html) {
 
 // 根据单个消息数据生成 HTML 结构
 export function createMessageHtml(message, index, searchValue) {
-    const position = message.user === '我' ? 'right' : 'left';
+    const position = Number(message.is_self) === 1 || message.user === '我' ? 'right' : 'left';
     const telegramUrl = chatUsername ? `https://t.me/${chatUsername}/${message.msg_id ?? ''}` : `https://t.me/c/${message.chat_id}/${message.msg_id ?? ''}`;
 
     // 1. 文本内容

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,21 +1,37 @@
 {
-    "name": "聊天记录App",
-    "short_name": "聊天记录",
-    "start_url": "/",
-    "display": "standalone",
-    "background_color": "#000000",
-    "theme_color": "#000000",
-    "orientation": "portrait",
-    "icons": [
-        {
-            "src": "/static/icons/icon-192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/static/icons/icon-512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ]
+  "id": "/",
+  "name": "Telegram Bot Archive",
+  "short_name": "TG Archive",
+  "description": "Telegram 聊天归档、跨频道搜索与媒体浏览的桌面/移动 PWA。",
+  "lang": "zh-CN",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone"],
+  "background_color": "#020617",
+  "theme_color": "#0f172a",
+  "orientation": "portrait",
+  "categories": ["productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/static/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/static/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "首页管理",
+      "short_name": "首页",
+      "url": "/",
+      "description": "管理聊天、执行全局搜索"
+    }
+  ]
 }

--- a/static/offline.html
+++ b/static/offline.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0f172a" />
+  <title>离线中</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      background: radial-gradient(circle at top, rgba(56,189,248,.18), transparent 38%), linear-gradient(180deg, #0f172a, #020617);
+      color: #e2e8f0;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+    .card {
+      width: min(520px, 100%);
+      padding: 28px;
+      border-radius: 24px;
+      background: rgba(15,23,42,.78);
+      border: 1px solid rgba(148,163,184,.2);
+      box-shadow: 0 24px 60px -40px rgba(0,0,0,.7);
+      backdrop-filter: blur(16px);
+    }
+    h1 { margin: 0 0 10px; font-size: 28px; }
+    p { margin: 0 0 14px; color: #94a3b8; line-height: 1.7; }
+    .tips { padding-left: 18px; color: #cbd5e1; }
+    .tips li { margin: 8px 0; }
+    a {
+      display: inline-flex; margin-top: 10px; color: white; text-decoration: none;
+      padding: 10px 16px; border-radius: 999px; background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>当前处于离线状态</h1>
+    <p>应用外壳已经安装完成，但你访问的内容需要网络或尚未缓存。恢复网络后刷新即可继续使用。</p>
+    <ul class="tips">
+      <li>已访问过的静态资源会优先从本地缓存读取。</li>
+      <li>首页和基础界面适合通过桌面快捷方式作为 PWA 使用。</li>
+      <li>聊天数据搜索、同步和媒体下载仍然依赖在线接口。</li>
+    </ul>
+    <a href="/">返回首页</a>
+  </div>
+</body>
+</html>

--- a/static/pwa.js
+++ b/static/pwa.js
@@ -1,0 +1,59 @@
+let deferredInstallPrompt = null;
+
+function setInstallVisibility(visible) {
+  document.querySelectorAll('[data-role="install-app"]').forEach((button) => {
+    button.hidden = !visible;
+    button.disabled = !visible;
+  });
+}
+
+function isStandaloneMode() {
+  return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+}
+
+async function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) return;
+  try {
+    await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+    document.documentElement.dataset.pwaReady = '1';
+  } catch (error) {
+    console.warn('service worker register failed', error);
+  }
+}
+
+function bindInstallButtons() {
+  document.querySelectorAll('[data-role="install-app"]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      if (!deferredInstallPrompt) return;
+      deferredInstallPrompt.prompt();
+      const result = await deferredInstallPrompt.userChoice;
+      if (result && result.outcome !== 'accepted') {
+        console.info('install dismissed');
+      }
+      deferredInstallPrompt = null;
+      setInstallVisibility(false);
+    });
+  });
+}
+
+window.addEventListener('beforeinstallprompt', (event) => {
+  event.preventDefault();
+  deferredInstallPrompt = event;
+  if (!isStandaloneMode()) {
+    setInstallVisibility(true);
+  }
+});
+
+window.addEventListener('appinstalled', () => {
+  deferredInstallPrompt = null;
+  setInstallVisibility(false);
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  bindInstallButtons();
+  if (isStandaloneMode()) {
+    document.documentElement.dataset.displayMode = 'standalone';
+    setInstallVisibility(false);
+  }
+  registerServiceWorker();
+});

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,69 @@
+const CACHE_VERSION = 'telegram-bot-pwa-v2';
+const APP_SHELL = [
+  '/',
+  '/static/manifest.json',
+  '/static/offline.html',
+  '/static/chat.css',
+  '/static/utils.js',
+  '/static/pwa.js',
+  '/static/resources/favicon.svg',
+  '/static/icons/icon-192.png',
+  '/static/icons/icon-512.png'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(APP_SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((key) => key !== CACHE_VERSION).map((key) => caches.delete(key)))).then(() => self.clients.claim())
+  );
+});
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  const cache = await caches.open(CACHE_VERSION);
+  cache.put(request, response.clone());
+  return response;
+}
+
+async function networkFirst(request) {
+  try {
+    const response = await fetch(request);
+    const cache = await caches.open(CACHE_VERSION);
+    cache.put(request, response.clone());
+    return response;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    if (request.mode === 'navigate') {
+      return caches.match('/static/offline.html');
+    }
+    throw error;
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (url.pathname.startsWith('/static/') || url.pathname.startsWith('/downloads/')) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  event.respondWith(networkFirst(request));
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -621,6 +621,34 @@
     </section>
 
     <section class="surface">
+      <h2 class="card-title">全局搜索</h2>
+      <p class="card-subtitle">跨多个频道/聊天统一搜索；可勾选范围并保存为搜索方案。</p>
+      <div class="form-field">
+        <label class="input-label" for="globalSearchQuery">搜索关键词</label>
+        <input type="text" id="globalSearchQuery" placeholder="输入关键词，可跨聊天搜索" />
+      </div>
+      <div class="form-field">
+        <label class="input-label" for="globalScopeSelect">已保存范围</label>
+        <select id="globalScopeSelect">
+          <option value="">不使用已保存范围</option>
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="input-label" for="globalSearchScopeName">保存当前勾选为范围</label>
+        <input type="text" id="globalSearchScopeName" placeholder="例如：常用频道 / 工作群" />
+      </div>
+      <div class="form-field">
+        <label class="input-label">选择要搜索的频道</label>
+        <div id="globalSearchChatChoices"></div>
+      </div>
+      <div class="sql-actions">
+        <button type="button" id="runGlobalSearch">执行全局搜索</button>
+        <button type="button" id="saveGlobalScope">保存搜索范围</button>
+      </div>
+      <pre id="globalSearchResults"></pre>
+    </section>
+
+    <section class="surface">
       <h2 class="card-title">SQL 调试工具</h2>
       <p class="card-subtitle">针对选中的聊天频道执行 SQL，并查看原始返回数据。</p>
       <textarea id="sql_str" placeholder="输入 SQL..."></textarea>
@@ -660,8 +688,119 @@
     }
 
     let selectedChatId = null;
+    let latestChats = [];
+    let latestScopes = [];
     const cleanupPollers = new Map();
     const cleanupButtons = new Map();
+
+    function getSelectedGlobalChatIds() {
+      return Array.from(document.querySelectorAll('#globalSearchChatChoices input[type="checkbox"]:checked')).map(el => el.value);
+    }
+
+    function renderGlobalSearchChatChoices() {
+      const root = document.getElementById('globalSearchChatChoices');
+      if (!root) return;
+      root.innerHTML = '';
+      latestChats.forEach(chat => {
+        const label = document.createElement('label');
+        label.className = 'option-item';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.value = chat.id;
+        const content = document.createElement('div');
+        content.className = 'option-item__content';
+        const title = document.createElement('span');
+        title.className = 'option-item__title';
+        title.textContent = chat.remark || chat.id;
+        const small = document.createElement('small');
+        small.textContent = [chat.id, chat.username || ''].filter(Boolean).join(' · ');
+        content.appendChild(title);
+        content.appendChild(small);
+        label.appendChild(checkbox);
+        label.appendChild(content);
+        root.appendChild(label);
+      });
+    }
+
+    function renderSearchScopes() {
+      const select = document.getElementById('globalScopeSelect');
+      if (!select) return;
+      const current = select.value;
+      select.innerHTML = '<option value="">不使用已保存范围</option>';
+      latestScopes.forEach(scope => {
+        const option = document.createElement('option');
+        option.value = String(scope.id);
+        option.textContent = `${scope.name}（${(scope.chat_ids || []).length}）`;
+        select.appendChild(option);
+      });
+      if (latestScopes.some(scope => String(scope.id) === current)) {
+        select.value = current;
+      }
+    }
+
+    async function loadSearchScopes() {
+      try {
+        const res = await fetch('search_scopes');
+        const data = await res.json();
+        latestScopes = Array.isArray(data.scopes) ? data.scopes : [];
+        renderSearchScopes();
+      } catch (e) {
+        latestScopes = [];
+        renderSearchScopes();
+      }
+    }
+
+    async function saveCurrentSearchScope() {
+      const name = document.getElementById('globalSearchScopeName')?.value?.trim();
+      const chatIds = getSelectedGlobalChatIds();
+      const selectedScopeId = document.getElementById('globalScopeSelect')?.value || '';
+      if (!name) {
+        showToast('请先填写范围名称。', 'error');
+        return;
+      }
+      if (!chatIds.length) {
+        showToast('请至少勾选一个频道。', 'error');
+        return;
+      }
+      const payload = { name, chat_ids: chatIds };
+      if (selectedScopeId) payload.scope_id = Number(selectedScopeId);
+      const res = await fetch('search_scopes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        showToast((data && data.error) || '保存搜索范围失败。', 'error');
+        return;
+      }
+      showToast('搜索范围已保存。');
+      document.getElementById('globalSearchScopeName').value = '';
+      await loadSearchScopes();
+      if (data && data.scope && data.scope.id) {
+        document.getElementById('globalScopeSelect').value = String(data.scope.id);
+      }
+    }
+
+    async function runGlobalSearch() {
+      const query = document.getElementById('globalSearchQuery')?.value?.trim() || '';
+      const scopeId = document.getElementById('globalScopeSelect')?.value || '';
+      const chatIds = getSelectedGlobalChatIds();
+      const params = new URLSearchParams();
+      params.set('q', query);
+      if (scopeId) params.set('scope_id', scopeId);
+      if (chatIds.length) params.set('chat_ids', chatIds.join(','));
+      const res = await fetch(`search_global?${params.toString()}`);
+      const data = await res.json();
+      const output = document.getElementById('globalSearchResults');
+      if (!res.ok) {
+        output.innerText = JSON.stringify(data, null, 2);
+        showToast((data && data.error) || '全局搜索失败。', 'error');
+        return;
+      }
+      output.innerText = JSON.stringify(data, null, 2);
+      showToast(`全局搜索完成，共 ${data.total ?? 0} 条。`);
+    }
 
     function setCleanupButtonState(chatId, state, jobId) {
       const btn = cleanupButtons.get(chatId);
@@ -732,10 +871,12 @@
       fetch('chats')
         .then(r => r.json())
         .then(data => {
+          latestChats = Array.isArray(data.chats) ? data.chats : [];
+          renderGlobalSearchChatChoices();
           const ul = document.getElementById('chatList');
           ul.innerHTML = '';
           cleanupButtons.clear();
-          data.chats.forEach(chat => {
+          latestChats.forEach(chat => {
             const li = document.createElement('li');
             li.className = 'chat-item';
 
@@ -1004,7 +1145,17 @@
     document.addEventListener('DOMContentLoaded', () => {
       bindDownloadImagesOnlyOption();
       loadChats();
+      loadSearchScopes();
       checkWorkers();
+      document.getElementById('runGlobalSearch')?.addEventListener('click', runGlobalSearch);
+      document.getElementById('saveGlobalScope')?.addEventListener('click', saveCurrentSearchScope);
+      document.getElementById('globalScopeSelect')?.addEventListener('change', (event) => {
+        const selected = latestScopes.find(scope => String(scope.id) === String(event.target.value || ''));
+        const ids = new Set(selected?.chat_ids || []);
+        document.querySelectorAll('#globalSearchChatChoices input[type="checkbox"]').forEach((el) => {
+          el.checked = ids.has(el.value);
+        });
+      });
     });
   </script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,11 @@
 
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0f172a" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <link rel="manifest" href="/static/manifest.json">
   <link rel="icon" href="/static/resources/favicon.svg" type="image/svg+xml">
   <title>聊天频道管理</title>
   <style>
@@ -63,6 +68,13 @@
       justify-content: space-between;
     }
 
+    .page-header__actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
     h1 {
       font-size: clamp(26px, 3vw, 36px);
       line-height: 1.1;
@@ -88,6 +100,12 @@
       padding: 13px 28px;
       cursor: pointer;
       transition: transform 0.18s ease, box-shadow 0.25s ease, background 0.25s ease, opacity 0.25s ease;
+    }
+
+    .ghost-button {
+      background: rgba(15, 23, 42, 0.72);
+      border: 1px solid rgba(148, 163, 184, 0.24);
+      box-shadow: none;
     }
 
     button:hover:not(:disabled) {
@@ -189,7 +207,8 @@
     }
 
     input[type="text"],
-    textarea {
+    textarea,
+    select {
       width: 100%;
       border: 1px solid rgba(148, 163, 184, 0.35);
       border-radius: 14px;
@@ -206,7 +225,8 @@
     }
 
     input[type="text"]:focus,
-    textarea:focus {
+    textarea:focus,
+    select:focus {
       border-color: rgba(56, 189, 248, 0.7);
       box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
       outline: none;
@@ -267,6 +287,28 @@
       font-weight: 600;
       color: var(--text-strong);
       letter-spacing: 0.01em;
+    }
+
+    #globalSearchChatChoices {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }
+
+    #globalSearchResults,
+    #sqlResult {
+      margin: 0;
+      min-height: 120px;
+      max-height: 420px;
+      overflow: auto;
+      padding: 16px;
+      border-radius: 16px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(2, 6, 23, 0.68);
+      color: #cbd5e1;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
     }
 
     .option-item small {
@@ -404,20 +446,11 @@
       padding-inline: 22px;
     }
 
+    #globalSearchResults,
     #sqlResult {
       margin: 22px 0 0;
-      background: rgba(15, 23, 42, 0.78);
-      border: 1px solid rgba(148, 163, 184, 0.22);
-      border-radius: 16px;
-      padding: 18px;
       font-family: "JetBrains Mono", "Fira Code", Consolas, monospace;
       font-size: 13px;
-      line-height: 1.6;
-      color: rgba(203, 213, 225, 0.92);
-      white-space: pre-wrap;
-      word-break: break-word;
-      max-height: 360px;
-      overflow: auto;
     }
 
     .helper-text {
@@ -550,7 +583,10 @@
         <h1>聊天频道管理</h1>
         <p class="subtitle">快速添加聊天频道、调整导出选项，并在同一处查看配置或执行 SQL 调试。</p>
       </div>
-      <button id="startWorkers" type="button">开始监听</button>
+      <div class="page-header__actions">
+        <button id="installAppButton" class="ghost-button" type="button" data-role="install-app" hidden disabled>安装 App</button>
+        <button id="startWorkers" type="button">开始监听</button>
+      </div>
     </header>
 
     <section class="surface">
@@ -659,6 +695,7 @@
     </section>
   </div>
 
+  <script src="/static/pwa.js"></script>
   <script>
     const toast = document.getElementById('toast');
     const toastMessage = document.getElementById('toastMessage');

--- a/templates/template.html
+++ b/templates/template.html
@@ -2,9 +2,12 @@
 
 <head>
     <meta charset="utf-8">
+    <meta name="theme-color" content="#0f172a">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="icon" href="/static/resources/favicon.svg" type="image/svg+xml">
     <link rel="manifest" href="/static/manifest.json">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>聊天记录</title>
     <link rel="stylesheet" href="/static/chat.css">
     <link rel="stylesheet" href="/static/components/message/index.css">
@@ -15,18 +18,23 @@
     <div id="chatToast" class="chat-toast" role="status" aria-live="polite"></div>
     <div class="container">
         <div id="header">
-            <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
-            <button id="confirmSearch">搜索</button>
-            <select id="chatSelect" class="select-component">
-            </select>
-            <select id="reactionSelect" class="select-component" title="表情排序">
-            </select>
-            <select id="repliesNumSelect" class="select-component" title="回复数排序">
-              <option value="">按回复数排序</option>
-              <option value="desc">回复数(高→低)</option>
-            </select>
-            <button id="downloadBrokenImages" title="下载该聊天所有缺失图片（按 10 张一批）">下载全部坏图</button>
-            <button id="exitReplies" class="hidden" title="返回聊天">返回</button>
+            <div class="header-main">
+              <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
+              <button id="confirmSearch">搜索</button>
+              <select id="chatSelect" class="select-component">
+              </select>
+              <select id="reactionSelect" class="select-component" title="表情排序">
+              </select>
+              <select id="repliesNumSelect" class="select-component" title="回复数排序">
+                <option value="">按回复数排序</option>
+                <option value="desc">回复数(高→低)</option>
+              </select>
+            </div>
+            <div class="header-actions">
+              <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>
+              <button id="downloadBrokenImages" title="下载该聊天所有缺失图片（按 10 张一批）">下载全部坏图</button>
+              <button id="exitReplies" class="hidden" title="返回聊天">返回</button>
+            </div>
         </div>
         <div id="topLoader" class="top-loader hidden" aria-hidden="true">
           <div class="top-loader__inner">
@@ -46,6 +54,7 @@
     </button>
     <script>window.CHAT_ID = "{{ chat_id }}"; window.CHAT_USERNAME = "{{ chat_username }}";</script>
     <script type="module" src="/static/utils.js"></script>
+    <script src="/static/pwa.js"></script>
     <script type="module" src="/static/components/message/index.js"></script>
     <script type="module" src="/static/components/separator/index.js"></script>
     <script type="module" src="/static/chat.js"></script>


### PR DESCRIPTION
## Summary
- unify all chats/messages into one SQLite database (`data/app.db`)
- fix self/other message alignment using `is_self` + `sender_id`
- add global search and saved search scopes
- add migration script for old `chats.json` + per-chat `messages.db`

## Verification
- `pytest -q`
- `python -m py_compile src/telegram_bot/db_utils.py src/telegram_bot/message_utils.py src/telegram_bot/web_server.py scripts/migrate_to_unified_db.py`

## Migration
Please back up `chats.json`, `data/`, `downloads/`, and `me_id.txt` before running:

```bash
python scripts/migrate_to_unified_db.py
```