### PR TITLE
fix: restore FastAPI template rendering

### DIFF
--- a/src/telegram_bot/web_server.py
+++ b/src/telegram_bot/web_server.py
@@ -675,14 +675,14 @@ def _cleanup_stale_links_worker(
 
 @app.get("/")
 def index_page(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html", {"request": request})
 
 
 @app.get("/chat/{chat_id}")
 def chat_page(chat_id: str, request: Request):
     chats = load_chats()
     chat_username = next((c.get('username') for c in chats if c.get('id') == chat_id), '')
-    return templates.TemplateResponse("template.html", {"request": request, "chat_id": chat_id, 'chat_username': chat_username})
+    return templates.TemplateResponse(request, "template.html", {"request": request, "chat_id": chat_id, 'chat_username': chat_username})
 
 
 @app.get("/sw.js")

--- a/src/test/test_web_server.py
+++ b/src/test/test_web_server.py
@@ -1,4 +1,6 @@
-from telegram_bot.web_server import _cleanup_link_provider
+from fastapi.testclient import TestClient
+
+from telegram_bot.web_server import _cleanup_link_provider, app
 
 
 class _FakeBdPan:
@@ -13,3 +15,12 @@ links = ['https://www.aliyundrive.com/s/N8aXBido1v1']
 def test_cleanup_link_provider_works():
     bdpan = _FakeBdPan()
     assert 'ali' == _cleanup_link_provider(links[0], set(providers), bdpan=bdpan)
+
+
+def test_index_page_renders_successfully():
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "聊天频道管理" in response.text


### PR DESCRIPTION
## Summary
- update `TemplateResponse` calls to pass `request` as the first argument for current FastAPI/Starlette versions
- add a regression test covering `/` so homepage rendering does not regress

## Test Plan
- `PYTHONPATH=src pytest -q`

Fixes the homepage 500 caused by `TypeError: unhashable type: 'dict'` after dependency upgrades.