### PR TITLE
fix: restore chat background and improve mobile layouts

### DIFF
--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8-sig")
+
+
+def test_chat_css_last_body_rule_keeps_bg_png_background():
+    css = _read("static/chat.css")
+    body_rules = re.findall(r"body\s*\{.*?\}", css, flags=re.S)
+
+    assert body_rules, "expected at least one body CSS rule"
+    assert "url('resources/bg.png')" in body_rules[-1]
+
+
+def test_chat_template_has_mobile_header_wrappers():
+    template = _read("templates/template.html")
+
+    assert 'class="header-search-row"' in template
+    assert 'class="header-filters"' in template
+
+
+def test_management_template_has_mobile_chat_actions_grid():
+    template = _read("templates/index.html")
+
+    assert '.chat-item {' in template
+    assert 'flex-direction: column;' in template
+    assert 'grid-template-columns: repeat(2, minmax(0, 1fr));' in template
+    assert 'grid-column: 1 / -1;' in template

--- a/static/chat.css
+++ b/static/chat.css
@@ -675,9 +675,10 @@ body {
     color: #e2e8f0;
     background-color: var(--app-bg);
     background-image:
-      radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 32%),
-      radial-gradient(circle at bottom right, rgba(139, 92, 246, 0.16), transparent 28%),
-      linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.98));
+      linear-gradient(180deg, rgba(2, 6, 23, 0.42), rgba(2, 6, 23, 0.68)),
+      url('resources/bg.png');
+    background-position: center top;
+    background-repeat: repeat;
     padding-bottom: max(16px, env(safe-area-inset-bottom));
 }
 
@@ -712,6 +713,29 @@ body {
     gap: 10px;
 }
 
+.header-main {
+    flex: 1 1 640px;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.header-search-row,
+.header-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+}
+
+.header-search-row {
+    justify-content: space-between;
+}
+
+.header-filters {
+    justify-content: flex-start;
+}
+
 #searchBox,
 .select-component {
     background: var(--control-bg);
@@ -723,6 +747,7 @@ body {
 
 #searchBox {
     width: min(360px, 100%);
+    flex: 1 1 260px;
     padding: 11px 14px;
 }
 
@@ -796,5 +821,73 @@ body {
 
     .top-loader {
         top: 120px;
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .container {
+        width: calc(100% - 12px);
+        padding-top: 10px;
+    }
+
+    #header {
+        width: calc(100% - 12px);
+        top: max(6px, env(safe-area-inset-top));
+        gap: 8px;
+        padding: 10px;
+        border-radius: 18px;
+    }
+
+    .header-main,
+    .header-actions {
+        width: 100%;
+    }
+
+    .header-search-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+    }
+
+    .header-filters {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+    }
+
+    #repliesNumSelect {
+        grid-column: 1 / -1;
+    }
+
+    #searchBox,
+    .select-component,
+    #confirmSearch,
+    #downloadBrokenImages,
+    #exitReplies,
+    .header-secondary {
+        width: 100%;
+        min-width: 0;
+        margin-left: 0;
+        font-size: 13px;
+    }
+
+    #confirmSearch {
+        width: auto;
+        min-width: 84px;
+        padding-inline: 14px;
+    }
+
+    .header-actions {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 8px;
+    }
+
+    #messages {
+        padding-top: 168px;
+    }
+
+    .top-loader {
+        top: 148px;
     }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -381,7 +381,10 @@
 
     .chat-actions {
       display: flex;
+      flex-wrap: wrap;
       align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
       padding: 10px 14px 10px 0;
     }
 
@@ -413,11 +416,12 @@
 
     .chat-actions button {
       padding: 10px 18px;
+      min-height: 42px;
       background: rgba(248, 113, 113, 0.15);
       border: 1px solid rgba(248, 113, 113, 0.35);
       color: #fecaca;
       box-shadow: none;
-      margin-left: 8px;
+      margin-left: 0;
     }
 
     .chat-actions button:hover:not(:disabled) {
@@ -539,6 +543,19 @@
         font-size: 26px;
       }
 
+      .page-header {
+        gap: 14px;
+      }
+
+      .page-header__actions {
+        width: 100%;
+      }
+
+      .page-header__actions button {
+        flex: 1 1 0;
+        min-width: 0;
+      }
+
       .add-form__grid {
         grid-template-columns: 1fr;
         gap: 22px;
@@ -551,6 +568,35 @@
 
       #addButton {
         width: 100%;
+      }
+
+      .chat-item {
+        flex-direction: column;
+      }
+
+      .chat-item label {
+        padding-bottom: 8px;
+      }
+
+      .chat-actions {
+        width: 100%;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
+        padding: 0 18px 18px;
+      }
+
+      .chat-toggle {
+        width: 100%;
+        margin-left: 0;
+        justify-content: center;
+        grid-column: 1 / -1;
+      }
+
+      .chat-actions button {
+        width: 100%;
+        padding: 10px 12px;
+        white-space: normal;
       }
 
       .sql-actions {

--- a/templates/template.html
+++ b/templates/template.html
@@ -19,16 +19,20 @@
     <div class="container">
         <div id="header">
             <div class="header-main">
-              <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
-              <button id="confirmSearch">搜索</button>
-              <select id="chatSelect" class="select-component">
-              </select>
-              <select id="reactionSelect" class="select-component" title="表情排序">
-              </select>
-              <select id="repliesNumSelect" class="select-component" title="回复数排序">
-                <option value="">按回复数排序</option>
-                <option value="desc">回复数(高→低)</option>
-              </select>
+              <div class="header-search-row">
+                <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
+                <button id="confirmSearch">搜索</button>
+              </div>
+              <div class="header-filters">
+                <select id="chatSelect" class="select-component">
+                </select>
+                <select id="reactionSelect" class="select-component" title="表情排序">
+                </select>
+                <select id="repliesNumSelect" class="select-component" title="回复数排序">
+                  <option value="">按回复数排序</option>
+                  <option value="desc">回复数(高→低)</option>
+                </select>
+              </div>
             </div>
             <div class="header-actions">
               <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>


### PR DESCRIPTION
## Summary
- restore the chat page background to use `static/resources/bg.png` again
- compress the mobile chat header by grouping search and filters into a denser responsive layout
- reflow management-page channel actions into a mobile grid so the four controls do not squash or deform
- add regression tests for the background asset hook and mobile layout structure

## Test Plan
- `PYTHONPATH=src pytest -q`

Addresses the background regression from #14 and the mobile layout issues reported after the UI refresh.