### PR TITLE
feat: collapse mobile chat search controls

### DIFF
--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -17,11 +17,39 @@ def test_chat_css_last_body_rule_keeps_bg_png_background():
     assert "url('resources/bg.png')" in body_rules[-1]
 
 
-def test_chat_template_has_mobile_header_wrappers():
+def test_chat_template_has_collapsible_mobile_search_shell():
     template = _read("templates/template.html")
 
-    assert 'class="header-search-row"' in template
-    assert 'class="header-filters"' in template
+    assert 'id="mobileSearchToggle"' in template
+    assert 'id="mobileSearchPanel"' in template
+    assert 'id="mobileControlsToggle"' in template
+    assert 'id="mobileSecondaryPanel"' in template
+    assert 'aria-label="展开搜索"' in template
+    assert 'aria-label="展开更多筛选"' in template
+
+
+def test_chat_template_uses_icon_buttons_for_search_and_expand_actions():
+    template = _read("templates/template.html")
+
+    assert re.search(r'<button id="confirmSearch"[^>]*>\s*<svg', template)
+    assert re.search(r'<button id="mobileControlsToggle"[^>]*>\s*<svg', template)
+
+
+def test_chat_js_controls_mobile_header_state():
+    script = _read("static/chat.js")
+
+    assert 'const mobileSearchToggle = document.getElementById(\'mobileSearchToggle\');' in script
+    assert 'mobileSearchPanel.classList.toggle(\'is-expanded\'' in script
+    assert 'mobileSecondaryPanel.classList.toggle(\'is-open\'' in script
+
+
+def test_chat_css_animates_mobile_search_panel_from_right():
+    css = _read("static/chat.css")
+
+    assert '.mobile-search-shell {' in css
+    assert 'transform-origin: right center;' in css
+    assert 'transition: width 0.28s ease, opacity 0.2s ease, transform 0.28s ease;' in css
+    assert '.mobile-secondary-panel.is-open {' in css
 
 
 def test_management_template_has_mobile_chat_actions_grid():

--- a/static/chat.css
+++ b/static/chat.css
@@ -669,6 +669,8 @@ body {
     --control-hover: rgba(30, 41, 59, 0.96);
     --accent-cyan: #38bdf8;
     --accent-violet: #8b5cf6;
+    --chat-header-offset: 108px;
+    --chat-loader-offset: 96px;
 }
 
 body {
@@ -705,8 +707,23 @@ body {
     top: max(10px, env(safe-area-inset-top));
 }
 
+.mobile-search-container {
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.mobile-search-shell {
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 100%;
+}
+
 .header-main,
-.header-actions {
+.header-actions,
+.mobile-secondary-panel {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -714,7 +731,7 @@ body {
 }
 
 .header-main {
-    flex: 1 1 640px;
+    width: 100%;
     flex-direction: column;
     align-items: stretch;
 }
@@ -729,11 +746,21 @@ body {
 }
 
 .header-search-row {
-    justify-content: space-between;
+    justify-content: flex-start;
+}
+
+.mobile-secondary-panel {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
 }
 
 .header-filters {
     justify-content: flex-start;
+}
+
+.header-actions {
+    justify-content: flex-end;
 }
 
 #searchBox,
@@ -755,17 +782,39 @@ body {
     color: rgba(226, 232, 240, 0.52);
 }
 
-#confirmSearch,
+.header-icon-button,
 #downloadBrokenImages,
 #exitReplies,
 .header-secondary {
     margin-left: 0;
     min-height: 42px;
-    padding: 0 16px;
     border-radius: 12px;
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(14, 165, 233, 0.25));
     border: 1px solid rgba(56, 189, 248, 0.22);
     color: #f8fafc;
+}
+
+.header-icon-button {
+    width: 42px;
+    min-width: 42px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.header-icon-button svg {
+    transition: transform 0.24s ease;
+}
+
+.mobile-controls-toggle.is-open svg {
+    transform: rotate(180deg);
+}
+
+#downloadBrokenImages,
+#exitReplies,
+.header-secondary {
+    padding: 0 16px;
     width: auto;
 }
 
@@ -774,20 +823,29 @@ body {
     border-color: rgba(148, 163, 184, 0.2);
 }
 
+#mobileSearchToggle {
+    display: none;
+}
+
+#mobileControlsToggle {
+    display: none;
+}
+
 #confirmSearch:hover,
 #downloadBrokenImages:hover,
 #exitReplies:hover,
 .header-secondary:hover,
-.select-component:hover {
+.select-component:hover,
+.header-icon-button:hover {
     background: var(--control-hover);
 }
 
 #messages {
-    padding: 108px 0 72px 0;
+    padding: var(--chat-header-offset) 0 72px 0;
 }
 
 .top-loader {
-    top: 96px;
+    top: var(--chat-loader-offset);
 }
 
 .top-loader__inner {
@@ -814,14 +872,6 @@ body {
     #header {
         width: calc(100% - 16px);
     }
-
-    #messages {
-        padding-top: 132px;
-    }
-
-    .top-loader {
-        top: 120px;
-    }
 }
 
 @media screen and (max-width: 768px) {
@@ -836,32 +886,77 @@ body {
         gap: 8px;
         padding: 10px;
         border-radius: 18px;
+        justify-content: flex-end;
     }
 
-    .header-main,
-    .header-actions {
-        width: 100%;
+    .mobile-search-container {
+        gap: 8px;
+    }
+
+    #mobileSearchToggle {
+        display: inline-flex;
+        flex: 0 0 auto;
+    }
+
+    .mobile-search-shell {
+        width: 0;
+        flex: 0 1 auto;
+        overflow: hidden;
+        opacity: 0;
+        transform: scaleX(0.78) translateX(10px);
+        transform-origin: right center;
+        pointer-events: none;
+        transition: width 0.28s ease, opacity 0.2s ease, transform 0.28s ease;
+    }
+
+    .mobile-search-shell.is-expanded {
+        width: min(320px, calc(100vw - 84px));
+        opacity: 1;
+        transform: scaleX(1) translateX(0);
+        pointer-events: auto;
     }
 
     .header-search-row {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) 42px 42px;
         gap: 8px;
+    }
+
+    #mobileControlsToggle {
+        display: inline-flex;
+    }
+
+    .mobile-secondary-panel {
+        max-height: 0;
+        opacity: 0;
+        overflow: hidden;
+        transform: translateY(-6px);
+        pointer-events: none;
+        transition: max-height 0.28s ease, opacity 0.2s ease, transform 0.28s ease;
+    }
+
+    .mobile-secondary-panel.is-open {
+        max-height: 420px;
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
     }
 
     .header-filters {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: 1fr;
         gap: 8px;
     }
 
-    #repliesNumSelect {
-        grid-column: 1 / -1;
+    .header-actions {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        justify-content: stretch;
     }
 
     #searchBox,
     .select-component,
-    #confirmSearch,
     #downloadBrokenImages,
     #exitReplies,
     .header-secondary {
@@ -871,23 +966,9 @@ body {
         font-size: 13px;
     }
 
-    #confirmSearch {
-        width: auto;
-        min-width: 84px;
-        padding-inline: 14px;
-    }
-
-    .header-actions {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 8px;
-    }
-
-    #messages {
-        padding-top: 168px;
-    }
-
-    .top-loader {
-        top: 148px;
+    #downloadBrokenImages,
+    #exitReplies,
+    .header-secondary {
+        justify-content: center;
     }
 }

--- a/static/chat.js
+++ b/static/chat.js
@@ -1303,9 +1303,99 @@ async function ensureSearchScrollable() {
 document.addEventListener('DOMContentLoaded', loadMessages);
 
 const confirmSearchBtn = document.getElementById('confirmSearch');
+const mobileSearchToggle = document.getElementById('mobileSearchToggle');
+const mobileSearchPanel = document.getElementById('mobileSearchPanel');
+const mobileControlsToggle = document.getElementById('mobileControlsToggle');
+const mobileSecondaryPanel = document.getElementById('mobileSecondaryPanel');
+const mobileHeaderMediaQuery = window.matchMedia('(max-width: 768px)');
+
+let isMobileSearchExpanded = false;
+let isMobileControlsExpanded = false;
+
+function updateHeaderOffsets() {
+    const header = document.getElementById('header');
+    if (!header) return;
+    const headerRect = header.getBoundingClientRect();
+    const headerBottom = Math.ceil(headerRect.bottom);
+    document.documentElement.style.setProperty('--chat-header-offset', `${headerBottom + 14}px`);
+    document.documentElement.style.setProperty('--chat-loader-offset', `${Math.max(56, headerBottom - 10)}px`);
+}
+
+function syncMobileHeaderState() {
+    if (!mobileSearchPanel || !mobileSecondaryPanel || !mobileSearchToggle || !mobileControlsToggle) return;
+
+    if (!mobileHeaderMediaQuery.matches) {
+        mobileSearchPanel.classList.add('is-expanded');
+        mobileSecondaryPanel.classList.add('is-open');
+        mobileSearchPanel.setAttribute('aria-hidden', 'false');
+        mobileSecondaryPanel.setAttribute('aria-hidden', 'false');
+        mobileControlsToggle.classList.remove('is-open');
+        mobileSearchToggle.setAttribute('aria-expanded', 'true');
+        mobileControlsToggle.setAttribute('aria-expanded', 'true');
+        requestAnimationFrame(updateHeaderOffsets);
+        return;
+    }
+
+    mobileSearchPanel.classList.toggle('is-expanded', isMobileSearchExpanded);
+    mobileSecondaryPanel.classList.toggle('is-open', isMobileSearchExpanded && isMobileControlsExpanded);
+    mobileControlsToggle.classList.toggle('is-open', isMobileSearchExpanded && isMobileControlsExpanded);
+    mobileSearchPanel.setAttribute('aria-hidden', String(!isMobileSearchExpanded));
+    mobileSecondaryPanel.setAttribute('aria-hidden', String(!(isMobileSearchExpanded && isMobileControlsExpanded)));
+    mobileSearchToggle.setAttribute('aria-expanded', String(isMobileSearchExpanded));
+    mobileControlsToggle.setAttribute('aria-expanded', String(isMobileSearchExpanded && isMobileControlsExpanded));
+    requestAnimationFrame(updateHeaderOffsets);
+}
+
+function toggleMobileSearchPanel(forceExpanded = !isMobileSearchExpanded) {
+    isMobileSearchExpanded = !!forceExpanded;
+    if (!isMobileSearchExpanded) {
+        isMobileControlsExpanded = false;
+    }
+    syncMobileHeaderState();
+    if (isMobileSearchExpanded) {
+        document.getElementById('searchBox')?.focus();
+    }
+}
+
+function toggleMobileControls(forceExpanded = !isMobileControlsExpanded) {
+    if (!isMobileHeaderMediaQuery.matches) return;
+    if (!isMobileSearchExpanded) {
+        isMobileSearchExpanded = true;
+    }
+    isMobileControlsExpanded = !!forceExpanded;
+    syncMobileHeaderState();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    syncMobileHeaderState();
+    mobileSearchToggle?.addEventListener('click', () => toggleMobileSearchPanel());
+    mobileControlsToggle?.addEventListener('click', () => toggleMobileControls());
+    window.addEventListener('resize', updateHeaderOffsets);
+    requestAnimationFrame(updateHeaderOffsets);
+});
+
+mobileHeaderMediaQuery.addEventListener('change', () => {
+    if (!mobileHeaderMediaQuery.matches) {
+        isMobileSearchExpanded = false;
+        isMobileControlsExpanded = false;
+    }
+    syncMobileHeaderState();
+});
+
+document.addEventListener('click', (event) => {
+    if (!mobileHeaderMediaQuery.matches || !isMobileSearchExpanded) return;
+    const header = document.getElementById('header');
+    if (header && !header.contains(event.target)) {
+        toggleMobileSearchPanel(false);
+    }
+});
+
 document.addEventListener('keydown', function (event) {
     if (event.key === 'Enter') {
         confirmSearchBtn.click();
+    }
+    if (event.key === 'Escape' && mobileHeaderMediaQuery.matches && isMobileSearchExpanded) {
+        toggleMobileSearchPanel(false);
     }
 });
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -18,26 +18,48 @@
     <div id="chatToast" class="chat-toast" role="status" aria-live="polite"></div>
     <div class="container">
         <div id="header">
-            <div class="header-main">
-              <div class="header-search-row">
-                <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
-                <button id="confirmSearch">搜索</button>
+            <div class="mobile-search-container">
+              <div id="mobileSearchPanel" class="mobile-search-shell" aria-hidden="true">
+                <div class="header-main">
+                  <div class="header-search-row">
+                    <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
+                    <button id="confirmSearch" class="header-icon-button" type="button" aria-label="执行搜索" title="搜索">
+                      <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="11" cy="11" r="7"></circle>
+                        <path d="m20 20-3.5-3.5"></path>
+                      </svg>
+                    </button>
+                    <button id="mobileControlsToggle" class="header-icon-button mobile-controls-toggle" type="button" aria-label="展开更多筛选" title="更多筛选">
+                      <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="m6 9 6 6 6-6"></path>
+                      </svg>
+                    </button>
+                  </div>
+                  <div id="mobileSecondaryPanel" class="mobile-secondary-panel" aria-hidden="true">
+                    <div class="header-filters">
+                      <select id="chatSelect" class="select-component">
+                      </select>
+                      <select id="reactionSelect" class="select-component" title="表情排序">
+                      </select>
+                      <select id="repliesNumSelect" class="select-component" title="回复数排序">
+                        <option value="">按回复数排序</option>
+                        <option value="desc">回复数(高→低)</option>
+                      </select>
+                      <button id="downloadBrokenImages" type="button" title="下载该聊天所有缺失图片（按 10 张一批）">下载坏图</button>
+                    </div>
+                    <div class="header-actions">
+                      <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>
+                      <button id="exitReplies" class="hidden" type="button" title="返回聊天">返回</button>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="header-filters">
-                <select id="chatSelect" class="select-component">
-                </select>
-                <select id="reactionSelect" class="select-component" title="表情排序">
-                </select>
-                <select id="repliesNumSelect" class="select-component" title="回复数排序">
-                  <option value="">按回复数排序</option>
-                  <option value="desc">回复数(高→低)</option>
-                </select>
-              </div>
-            </div>
-            <div class="header-actions">
-              <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>
-              <button id="downloadBrokenImages" title="下载该聊天所有缺失图片（按 10 张一批）">下载全部坏图</button>
-              <button id="exitReplies" class="hidden" title="返回聊天">返回</button>
+              <button id="mobileSearchToggle" class="header-icon-button mobile-search-trigger" type="button" aria-label="展开搜索" title="搜索">
+                <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="11" cy="11" r="7"></circle>
+                  <path d="m20 20-3.5-3.5"></path>
+                </svg>
+              </button>
             </div>
         </div>
         <div id="topLoader" class="top-loader hidden" aria-hidden="true">


### PR DESCRIPTION
## Summary
- make the mobile chat header start as a single search icon on the top-right
- animate the search shell to expand leftward into a search input plus icon-only search and expand buttons
- reveal chat switcher, reaction sort, replies sort, and download-broken-images controls only after opening the secondary panel
- keep desktop behavior intact and add regression tests for the new mobile header structure and state hooks

## Test Plan
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python - <<'PY' ... client.get('/chat/test-chat') ... PY`

Implements the revised mobile interaction requested after trying PR #16.