### PR TITLE
feat: migrate legacy metadata into app db and simplify mobile header

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Database migration helpers for legacy on-disk storage."""

--- a/scripts/migrate_legacy_storage_to_db.py
+++ b/scripts/migrate_legacy_storage_to_db.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from telegram_bot.db_utils import get_app_connection, set_me_id, set_og_cache, upsert_chat
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_json_file(path: Path) -> dict | list | None:
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as infile:
+        return json.load(infile)
+
+
+def migrate_legacy_storage(
+    *,
+    app_db_path: Path | str | None = None,
+    chats_file: Path | str | None = None,
+    me_id_file: Path | str | None = None,
+    og_data_file: Path | str | None = None,
+) -> dict:
+    app_db_path = Path(app_db_path) if app_db_path else ROOT / "data" / "app.db"
+    chats_file = Path(chats_file) if chats_file else ROOT / "chats.json"
+    me_id_file = Path(me_id_file) if me_id_file else ROOT / "me_id.txt"
+    og_data_file = Path(og_data_file) if og_data_file else ROOT / "data" / "og_data.json"
+
+    from telegram_bot import db_utils
+
+    db_utils.APP_DB_PATH = app_db_path
+
+    summary = {
+        "app_db_path": str(app_db_path),
+        "migrated_chats": 0,
+        "migrated_me_id": False,
+        "migrated_og_entries": 0,
+    }
+
+    conn = get_app_connection()
+    try:
+        chats_data = _load_json_file(chats_file)
+        if isinstance(chats_data, list):
+            for item in chats_data:
+                if isinstance(item, dict) and (item.get("id") or item.get("chat_id")):
+                    upsert_chat(conn, item)
+                    summary["migrated_chats"] += 1
+
+        if me_id_file.exists():
+            me_id = me_id_file.read_text(encoding="utf-8").strip()
+            if me_id:
+                set_me_id(conn, me_id)
+                summary["migrated_me_id"] = True
+
+        og_data = _load_json_file(og_data_file)
+        if isinstance(og_data, dict):
+            for url, value in og_data.items():
+                set_og_cache(conn, str(url), value if isinstance(value, dict) else {})
+                summary["migrated_og_entries"] += 1
+    finally:
+        conn.close()
+
+    return summary
+
+
+def main() -> int:
+    summary = migrate_legacy_storage()
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/telegram_bot/db_utils.py
+++ b/src/telegram_bot/db_utils.py
@@ -96,6 +96,15 @@ def init_db(conn):
         )
     '''
     )
+    conn.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS og_cache(
+            url TEXT PRIMARY KEY,
+            value TEXT,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        )
+    '''
+    )
 
     try:
         cols = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
@@ -403,6 +412,47 @@ def _meta_set(conn, key: str, value):
     conn.execute(
         "INSERT OR REPLACE INTO meta(chat_id, key, value) VALUES(?, ?, ?)",
         (chat_scope, key, str(value)),
+    )
+    conn.commit()
+
+
+def get_me_id(conn: sqlite3.Connection | None = None) -> str:
+    owns_conn = conn is None
+    conn = conn or get_app_connection()
+    try:
+        row = conn.execute("SELECT value FROM meta WHERE chat_id='' AND key='me_id'").fetchone()
+        return str(row[0]).strip() if row and row[0] is not None else ""
+    finally:
+        if owns_conn:
+            conn.close()
+
+
+def set_me_id(conn: sqlite3.Connection, value: str) -> None:
+    conn.execute(
+        "INSERT OR REPLACE INTO meta(chat_id, key, value) VALUES('', 'me_id', ?)",
+        (str(value or '').strip(),),
+    )
+    conn.commit()
+
+
+def get_og_cache(conn: sqlite3.Connection, url: str) -> dict | None:
+    row = conn.execute("SELECT value FROM og_cache WHERE url=?", (str(url or '').strip(),)).fetchone()
+    if not row:
+        return None
+    raw = row[0]
+    if raw in (None, ""):
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+
+def set_og_cache(conn: sqlite3.Connection, url: str, value: dict | None) -> None:
+    payload = json.dumps(value or {}, ensure_ascii=False)
+    conn.execute(
+        "INSERT OR REPLACE INTO og_cache(url, value, updated_at) VALUES(?, ?, ?)",
+        (str(url or '').strip(), payload, int(time.time())),
     )
     conn.commit()
 

--- a/src/telegram_bot/message_utils.py
+++ b/src/telegram_bot/message_utils.py
@@ -8,7 +8,7 @@ import re
 
 from .xunlei_cipher import is_xunlei_link_stale
 from .http_client import post as http_post
-from .paths import ME_ID_FILE
+from .db_utils import get_me_id as _get_me_id_from_db
 
 def load_json(file_path: str) -> dict:
     """Load JSON data from a file."""
@@ -16,11 +16,9 @@ def load_json(file_path: str) -> dict:
         return json.load(infile)
 
 def load_me_id() -> str:
-    """Load the user's own Telegram ID from a file."""
+    """Load the user's own Telegram ID from the app database."""
     try:
-        with open(ME_ID_FILE, "r", encoding="utf-8") as infile:
-            me_id = infile.read().strip()
-            return me_id
+        return _get_me_id_from_db()
     except Exception:
         return ""
 

--- a/src/telegram_bot/og_utils.py
+++ b/src/telegram_bot/og_utils.py
@@ -15,22 +15,34 @@ from PIL import Image
 from telegram_bot.http_client import get as http_get
 from telegram_bot.project_logger import get_logger
 from telegram_bot.update_messages import download
-from telegram_bot.paths import BASE_DIR, DATA_DIR, ensure_runtime_dirs
+from telegram_bot.paths import BASE_DIR, ensure_runtime_dirs
+from telegram_bot.db_utils import get_app_connection, get_og_cache, set_og_cache
 
 ensure_runtime_dirs()
-OG_DATA_FILE = DATA_DIR / "og_data.json"
 
 
 def load_og_data() -> dict:
-    if OG_DATA_FILE.exists():
-        with OG_DATA_FILE.open('r', encoding='utf-8') as file:
-            return json.load(file)
-    return {}
+    conn = get_app_connection()
+    try:
+        rows = conn.execute("SELECT url, value FROM og_cache").fetchall()
+        data: dict = {}
+        for url, raw in rows:
+            try:
+                data[url] = json.loads(raw) if raw else {}
+            except Exception:
+                data[url] = {}
+        return data
+    finally:
+        conn.close()
 
 
 def save_og_data(og_data: dict) -> None:
-    with OG_DATA_FILE.open('w', encoding='utf-8') as file:
-        json.dump(og_data, file, ensure_ascii=False, indent=4)
+    conn = get_app_connection()
+    try:
+        for url, value in (og_data or {}).items():
+            set_og_cache(conn, str(url), value if isinstance(value, dict) else {})
+    finally:
+        conn.close()
 
 
 def generate_url_key(url: str) -> str:
@@ -56,80 +68,71 @@ def calculate_size(file_path: str, og_width: int | None, og_height: int | None) 
     return original_width, original_height
 
 def get_open_graph_info(url: str, chat_id: str | None = None) -> dict | None:
-    og_data = load_og_data()
-    if url in og_data and og_data[url]:
-        return og_data[url]
+    conn = get_app_connection()
     try:
-        headers = {
-            'User-Agent': r"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 TelegramBot (like TwitterBot)"
-        }
-        response = http_get(url, timeout=5, headers=headers)
-        if response.status_code != 200:
-            og_data[url] = {}
-            save_og_data(og_data)
+        cached = get_og_cache(conn, url)
+        if cached:
+            return cached
+        if cached == {}:
             return None
+        try:
+            headers = {
+                'User-Agent': r"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 TelegramBot (like TwitterBot)"
+            }
+            response = http_get(url, timeout=5, headers=headers)
+            if response.status_code != 200:
+                set_og_cache(conn, url, {})
+                return None
 
-        parsed_url = urlparse(url)
-        domain_parts = parsed_url.netloc.split(':')[0].split('.')
-        domain = domain_parts[-2] if len(domain_parts) >= 2 else domain_parts[0]
-        if domain.lower() == 'b23':
-            domain = 'bilibili'
-        soup = BeautifulSoup(response.text, 'html.parser')
-        if domain.lower() == 'tiktok':
-            data_script = soup.find('script', {'id': '__UNIVERSAL_DATA_FOR_REHYDRATION__'})
-            if data_script:
-                json_data = json.loads(data_script.get_text()) if data_script and data_script.get_text() else {}
-                json_data = json_data.get('__DEFAULT_SCOPE__', {})
-                video_detail = json_data.get('webapp.video-detail', {})
-                cover = video_detail.get('itemInfo', {}).get('itemStruct', {}).get('video', {}).get('cover')
-                share_meta = video_detail.get('shareMeta', {})
-                og_info = {
-                    'title': share_meta.get('title'),
-                    'image': cover,
-                    'description': share_meta.get('desc'),
-                    'site_name': domain.capitalize(),
-                    'width': None,
-                    'height': None,
-                    'url': url,
-                }
-                og_data[url] = og_info
-                save_og_data(og_data)
-                return og_info
-        og_title = soup.find('meta', property='og:title')
-        og_image = soup.find('meta', property='og:image')
-        og_description = soup.find('meta', property='og:description')
-        og_site_name = soup.find('meta', property='og:site_name')
-        og_width = soup.find('meta', property='og:image:width') or soup.find('meta', property='og:width')
-        og_height = soup.find('meta', property='og:image:height') or soup.find('meta', property='og:height')
-        og_url = soup.find('meta', property='og:url')
-        # if og_image and isinstance(og_image, Tag):
-            # content = og_image.get('content', '')
-            # img_url = content
-            # if isinstance(content, str) and content.startswith('//'):
-                # img_url = f'{parsed_url.scheme}:{content}'
-            # path = download(img_url, chat_id) if chat_id else None
-            # if path and os.path.exists(path):
-            #     try:
-            #         og_image['content'] = Path(path).resolve().relative_to(BASE_DIR).as_posix()
-            #     except Exception:
-            #         og_image['content'] = path
+            parsed_url = urlparse(url)
+            domain_parts = parsed_url.netloc.split(':')[0].split('.')
+            domain = domain_parts[-2] if len(domain_parts) >= 2 else domain_parts[0]
+            if domain.lower() == 'b23':
+                domain = 'bilibili'
+            soup = BeautifulSoup(response.text, 'html.parser')
+            if domain.lower() == 'tiktok':
+                data_script = soup.find('script', {'id': '__UNIVERSAL_DATA_FOR_REHYDRATION__'})
+                if data_script:
+                    json_data = json.loads(data_script.get_text()) if data_script and data_script.get_text() else {}
+                    json_data = json_data.get('__DEFAULT_SCOPE__', {})
+                    video_detail = json_data.get('webapp.video-detail', {})
+                    cover = video_detail.get('itemInfo', {}).get('itemStruct', {}).get('video', {}).get('cover')
+                    share_meta = video_detail.get('shareMeta', {})
+                    og_info = {
+                        'title': share_meta.get('title'),
+                        'image': cover,
+                        'description': share_meta.get('desc'),
+                        'site_name': domain.capitalize(),
+                        'width': None,
+                        'height': None,
+                        'url': url,
+                    }
+                    set_og_cache(conn, url, og_info)
+                    return og_info
+            og_title = soup.find('meta', property='og:title')
+            og_image = soup.find('meta', property='og:image')
+            og_description = soup.find('meta', property='og:description')
+            og_site_name = soup.find('meta', property='og:site_name')
+            og_width = soup.find('meta', property='og:image:width') or soup.find('meta', property='og:width')
+            og_height = soup.find('meta', property='og:image:height') or soup.find('meta', property='og:height')
+            og_url = soup.find('meta', property='og:url')
 
-        og_info = {
-            'title': og_title['content'] if isinstance(og_title, Tag) and 'content' in og_title.attrs else None,
-            'image': og_image['content'] if isinstance(og_image, Tag) and 'content' in og_image.attrs else None,
-            'description': og_description.get('content') if isinstance(og_description, Tag) else None,
-            'site_name': og_site_name['content'] if isinstance(og_site_name, Tag) and 'content' in og_site_name.attrs else domain.capitalize(),
-            'width': og_width['content'] if isinstance(og_width, Tag) and 'content' in og_width.attrs else None,
-            'height': og_height['content'] if isinstance(og_height, Tag) and 'content' in og_height.attrs else None,
-            'url': og_url['content'] if isinstance(og_url, Tag) and 'content' in og_url.attrs else None,
-        }
-        og_data[url] = og_info
-        save_og_data(og_data)
-        return og_info
-    except httpx.HTTPError as e:
-        logger = get_logger()
-        logger.exception(f'error og:{e}')
-        og_data[url] = {}
-        save_og_data(og_data)
-        return None
+            og_info = {
+                'title': og_title['content'] if isinstance(og_title, Tag) and 'content' in og_title.attrs else None,
+                'image': og_image['content'] if isinstance(og_image, Tag) and 'content' in og_image.attrs else None,
+                'description': og_description.get('content') if isinstance(og_description, Tag) else None,
+                'site_name': og_site_name['content'] if isinstance(og_site_name, Tag) and 'content' in og_site_name.attrs else domain.capitalize(),
+                'width': og_width['content'] if isinstance(og_width, Tag) and 'content' in og_width.attrs else None,
+                'height': og_height['content'] if isinstance(og_height, Tag) and 'content' in og_height.attrs else None,
+                'url': og_url['content'] if isinstance(og_url, Tag) and 'content' in og_url.attrs else None,
+            }
+            set_og_cache(conn, url, og_info)
+            return og_info
+        except httpx.HTTPError as e:
+            logger = get_logger()
+            logger.exception(f'error og:{e}')
+            set_og_cache(conn, url, {})
+            return None
+    finally:
+        conn.close()
 

--- a/src/telegram_bot/paths.py
+++ b/src/telegram_bot/paths.py
@@ -9,11 +9,9 @@ DOWNLOADS_DIR = BASE_DIR / "downloads"
 LOGS_DIR = BASE_DIR / "logs"
 STATIC_DIR = BASE_DIR / "static"
 TEMPLATES_DIR = BASE_DIR / "templates"
-ME_ID_FILE = BASE_DIR / "me_id.txt"
 
 
 def ensure_runtime_dirs() -> None:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     DOWNLOADS_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
-    ME_ID_FILE.touch(exist_ok=True)

--- a/src/telegram_bot/web_server.py
+++ b/src/telegram_bot/web_server.py
@@ -131,17 +131,7 @@ def workers_started() -> bool:
 def load_chats() -> list[dict]:
     conn = get_app_connection(row_factory=sqlite3.Row)
     try:
-        chats = list_chats_db(conn)
-        if chats:
-            return chats
-        if os.path.exists(CHATS_FILE):
-            with open(CHATS_FILE, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            if isinstance(data, list):
-                for chat in data:
-                    upsert_chat(conn, chat)
-                return list_chats_db(conn)
-        return []
+        return list_chats_db(conn)
     finally:
         conn.close()
 

--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -17,11 +17,41 @@ def test_chat_css_last_body_rule_keeps_bg_png_background():
     assert "url('resources/bg.png')" in body_rules[-1]
 
 
-def test_chat_template_has_mobile_header_wrappers():
+def test_chat_template_has_collapsed_mobile_search_trigger_and_expand_panel():
     template = _read("templates/template.html")
 
-    assert 'class="header-search-row"' in template
-    assert 'class="header-filters"' in template
+    assert 'id="mobileSearchTrigger"' in template
+    assert 'id="mobileSearchExpanded"' in template
+    assert 'id="mobileSearchPanel"' in template
+    assert 'aria-label="展开搜索"' in template
+    assert 'aria-label="展开更多筛选"' in template
+
+
+def test_chat_template_uses_icon_buttons_for_search_actions():
+    template = _read("templates/template.html")
+
+    assert re.search(r'<button id="mobileSearchTrigger"[^>]*>\s*<svg', template)
+    assert re.search(r'<button id="confirmSearch"[^>]*>\s*<svg', template)
+    assert re.search(r'<button id="mobileControlsToggle"[^>]*>\s*<svg', template)
+
+
+def test_chat_js_controls_mobile_search_expand_state():
+    script = _read("static/chat.js")
+
+    assert "const mobileSearchTrigger = document.getElementById('mobileSearchTrigger');" in script
+    assert "mobileSearchExpanded.classList.toggle('is-visible'" in script
+    assert "mobileSearchTrigger.classList.toggle('is-hidden'" in script
+    assert "mobileSearchPanel.classList.toggle('is-open'" in script
+
+
+def test_chat_css_uses_transparent_default_header_and_left_expand_animation():
+    css = _read("static/chat.css")
+
+    assert '#header.is-collapsed {' in css
+    assert 'background: transparent;' in css
+    assert '.mobile-search-expanded.is-visible {' in css
+    assert 'transform-origin: right center;' in css
+    assert 'translateX(0)' in css
 
 
 def test_management_template_has_mobile_chat_actions_grid():

--- a/src/test/test_unified_db.py
+++ b/src/test/test_unified_db.py
@@ -1,6 +1,14 @@
 import sqlite3
+import sys
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from telegram_bot import db_utils, message_utils
+from scripts import migrate_legacy_storage_to_db
 
 
 def test_parse_messages_sets_sender_id_and_is_self(monkeypatch):
@@ -46,7 +54,7 @@ def test_init_app_db_creates_unified_tables(tmp_path, monkeypatch):
     finally:
         conn.close()
 
-    assert {"chats", "messages", "search_scopes", "search_scope_items", "meta"}.issubset(tables)
+    assert {"chats", "messages", "search_scopes", "search_scope_items", "meta", "og_cache"}.issubset(tables)
 
 
 def test_unified_chat_scope_and_global_search(tmp_path, monkeypatch):
@@ -135,3 +143,59 @@ def test_upsert_search_scope_rejects_missing_scope_id(tmp_path, monkeypatch):
         conn.close()
 
     assert raised is True
+
+
+def test_db_stores_me_id_and_open_graph_cache(tmp_path, monkeypatch):
+    app_db = tmp_path / "app.db"
+    monkeypatch.setattr(db_utils, "APP_DB_PATH", app_db)
+
+    conn = db_utils.get_app_connection(row_factory=sqlite3.Row)
+    try:
+        db_utils.set_me_id(conn, "42")
+        db_utils.set_og_cache(conn, "https://example.com", {"title": "Example"})
+        db_utils.set_og_cache(conn, "https://missing.example", {})
+
+        me_id = db_utils.get_me_id(conn)
+        og_hit = db_utils.get_og_cache(conn, "https://example.com")
+        og_miss = db_utils.get_og_cache(conn, "https://missing.example")
+    finally:
+        conn.close()
+
+    assert me_id == "42"
+    assert og_hit == {"title": "Example"}
+    assert og_miss == {}
+
+
+def test_migrate_legacy_storage_imports_files_into_db(tmp_path):
+    app_db = tmp_path / "app.db"
+    chats_file = tmp_path / "chats.json"
+    me_id_file = tmp_path / "me_id.txt"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    og_data_file = data_dir / "og_data.json"
+
+    chats_file.write_text('[{"id": "chat-9", "remark": "旧频道"}]', encoding='utf-8')
+    me_id_file.write_text('777', encoding='utf-8')
+    og_data_file.write_text('{"https://example.com": {"title": "Legacy"}}', encoding='utf-8')
+
+    summary = migrate_legacy_storage_to_db.migrate_legacy_storage(
+        app_db_path=app_db,
+        chats_file=chats_file,
+        me_id_file=me_id_file,
+        og_data_file=og_data_file,
+    )
+
+    conn = db_utils.get_app_connection(row_factory=sqlite3.Row)
+    try:
+        chats = db_utils.list_chats_db(conn)
+        me_id = db_utils.get_me_id(conn)
+        og_info = db_utils.get_og_cache(conn, "https://example.com")
+    finally:
+        conn.close()
+
+    assert summary["migrated_chats"] == 1
+    assert summary["migrated_me_id"] is True
+    assert summary["migrated_og_entries"] == 1
+    assert chats[0]["id"] == "chat-9"
+    assert me_id == "777"
+    assert og_info == {"title": "Legacy"}

--- a/static/chat.css
+++ b/static/chat.css
@@ -669,6 +669,8 @@ body {
     --control-hover: rgba(30, 41, 59, 0.96);
     --accent-cyan: #38bdf8;
     --accent-violet: #8b5cf6;
+    --chat-header-offset: 108px;
+    --chat-loader-offset: 96px;
 }
 
 body {
@@ -705,21 +707,15 @@ body {
     top: max(10px, env(safe-area-inset-top));
 }
 
-.header-main,
-.header-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 10px;
+.mobile-search-trigger {
+    display: none;
 }
 
-.header-main {
-    flex: 1 1 640px;
-    flex-direction: column;
-    align-items: stretch;
+.mobile-search-expanded {
+    width: 100%;
 }
 
-.header-search-row,
+.mobile-search-panel,
 .header-filters {
     display: flex;
     flex-wrap: wrap;
@@ -728,12 +724,8 @@ body {
     width: 100%;
 }
 
-.header-search-row {
-    justify-content: space-between;
-}
-
-.header-filters {
-    justify-content: flex-start;
+.mobile-search-panel {
+    margin-top: 10px;
 }
 
 #searchBox,
@@ -745,9 +737,16 @@ body {
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
 }
 
+.header-search-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 42px 42px;
+    gap: 10px;
+    align-items: center;
+}
+
 #searchBox {
-    width: min(360px, 100%);
-    flex: 1 1 260px;
+    width: 100%;
+    min-width: 0;
     padding: 11px 14px;
 }
 
@@ -755,18 +754,39 @@ body {
     color: rgba(226, 232, 240, 0.52);
 }
 
-#confirmSearch,
+.header-icon-button,
 #downloadBrokenImages,
 #exitReplies,
 .header-secondary {
     margin-left: 0;
     min-height: 42px;
-    padding: 0 16px;
     border-radius: 12px;
-    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(14, 165, 233, 0.25));
     border: 1px solid rgba(56, 189, 248, 0.22);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(14, 165, 233, 0.25));
     color: #f8fafc;
-    width: auto;
+}
+
+.header-icon-button {
+    width: 42px;
+    min-width: 42px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.header-icon-button svg {
+    transition: transform 0.24s ease;
+}
+
+.mobile-controls-toggle.is-open svg {
+    transform: rotate(180deg);
+}
+
+#downloadBrokenImages,
+#exitReplies,
+.header-secondary {
+    padding: 0 16px;
 }
 
 .header-secondary {
@@ -778,16 +798,17 @@ body {
 #downloadBrokenImages:hover,
 #exitReplies:hover,
 .header-secondary:hover,
-.select-component:hover {
+.select-component:hover,
+.header-icon-button:hover {
     background: var(--control-hover);
 }
 
 #messages {
-    padding: 108px 0 72px 0;
+    padding: var(--chat-header-offset) 0 72px 0;
 }
 
 .top-loader {
-    top: 96px;
+    top: var(--chat-loader-offset);
 }
 
 .top-loader__inner {
@@ -814,14 +835,6 @@ body {
     #header {
         width: calc(100% - 16px);
     }
-
-    #messages {
-        padding-top: 132px;
-    }
-
-    .top-loader {
-        top: 120px;
-    }
 }
 
 @media screen and (max-width: 768px) {
@@ -833,61 +846,89 @@ body {
     #header {
         width: calc(100% - 12px);
         top: max(6px, env(safe-area-inset-top));
-        gap: 8px;
-        padding: 10px;
-        border-radius: 18px;
+        padding: 0;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        backdrop-filter: none;
+        background: transparent;
+        justify-content: flex-end;
     }
 
-    .header-main,
-    .header-actions {
-        width: 100%;
+    #header.is-collapsed {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+    }
+
+    .mobile-search-trigger {
+        display: inline-flex;
+    }
+
+    .mobile-search-trigger.is-hidden {
+        display: none;
+    }
+
+    .mobile-search-expanded {
+        width: 0;
+        opacity: 0;
+        overflow: hidden;
+        pointer-events: none;
+        transform: translateX(18px) scaleX(0.86);
+        transform-origin: right center;
+        transition: width 0.3s ease, opacity 0.22s ease, transform 0.3s ease;
+    }
+
+    .mobile-search-expanded.is-visible {
+        width: min(340px, calc(100vw - 28px));
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateX(0) scaleX(1);
     }
 
     .header-search-row {
-        display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
-        gap: 8px;
+        background: rgba(2, 6, 23, 0.82);
+        border: 1px solid var(--panel-border);
+        border-radius: 18px;
+        padding: 10px;
+        box-shadow: var(--panel-shadow);
+    }
+
+    .mobile-search-panel {
+        max-height: 0;
+        margin-top: 8px;
+        overflow: hidden;
+        opacity: 0;
+        transform: translateY(-6px);
+        pointer-events: none;
+        transition: max-height 0.28s ease, opacity 0.2s ease, transform 0.28s ease;
+    }
+
+    .mobile-search-panel.is-open {
+        max-height: 420px;
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
     }
 
     .header-filters {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: 1fr;
         gap: 8px;
-    }
-
-    #repliesNumSelect {
-        grid-column: 1 / -1;
+        background: rgba(2, 6, 23, 0.82);
+        border: 1px solid var(--panel-border);
+        border-radius: 18px;
+        padding: 12px;
+        box-shadow: var(--panel-shadow);
     }
 
     #searchBox,
     .select-component,
-    #confirmSearch,
     #downloadBrokenImages,
     #exitReplies,
     .header-secondary {
         width: 100%;
         min-width: 0;
-        margin-left: 0;
         font-size: 13px;
-    }
-
-    #confirmSearch {
-        width: auto;
-        min-width: 84px;
-        padding-inline: 14px;
-    }
-
-    .header-actions {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-        gap: 8px;
-    }
-
-    #messages {
-        padding-top: 168px;
-    }
-
-    .top-loader {
-        top: 148px;
     }
 }

--- a/static/chat.js
+++ b/static/chat.js
@@ -1303,9 +1303,97 @@ async function ensureSearchScrollable() {
 document.addEventListener('DOMContentLoaded', loadMessages);
 
 const confirmSearchBtn = document.getElementById('confirmSearch');
+const mobileSearchTrigger = document.getElementById('mobileSearchTrigger');
+const mobileSearchExpanded = document.getElementById('mobileSearchExpanded');
+const mobileSearchPanel = document.getElementById('mobileSearchPanel');
+const mobileControlsToggle = document.getElementById('mobileControlsToggle');
+const headerEl = document.getElementById('header');
+const mobileHeaderMediaQuery = window.matchMedia('(max-width: 768px)');
+
+let isMobileSearchVisible = false;
+let isMobileControlsOpen = false;
+
+function updateHeaderOffsets() {
+    if (!headerEl) return;
+    const headerBottom = Math.ceil(headerEl.getBoundingClientRect().bottom);
+    document.documentElement.style.setProperty('--chat-header-offset', `${headerBottom + 14}px`);
+    document.documentElement.style.setProperty('--chat-loader-offset', `${Math.max(56, headerBottom - 10)}px`);
+}
+
+function syncMobileHeaderState() {
+    if (!headerEl || !mobileSearchTrigger || !mobileSearchExpanded || !mobileSearchPanel) return;
+
+    if (!mobileHeaderMediaQuery.matches) {
+        headerEl.classList.remove('is-collapsed');
+        mobileSearchTrigger.classList.remove('is-hidden');
+        mobileSearchExpanded.classList.add('is-visible');
+        mobileSearchPanel.classList.add('is-open');
+        mobileSearchExpanded.setAttribute('aria-hidden', 'false');
+        mobileSearchPanel.setAttribute('aria-hidden', 'false');
+        mobileControlsToggle?.classList.add('is-open');
+        requestAnimationFrame(updateHeaderOffsets);
+        return;
+    }
+
+    headerEl.classList.toggle('is-collapsed', !isMobileSearchVisible);
+    mobileSearchTrigger.classList.toggle('is-hidden', isMobileSearchVisible);
+    mobileSearchExpanded.classList.toggle('is-visible', isMobileSearchVisible);
+    mobileSearchPanel.classList.toggle('is-open', isMobileSearchVisible && isMobileControlsOpen);
+    mobileControlsToggle?.classList.toggle('is-open', isMobileSearchVisible && isMobileControlsOpen);
+    mobileSearchExpanded.setAttribute('aria-hidden', String(!isMobileSearchVisible));
+    mobileSearchPanel.setAttribute('aria-hidden', String(!(isMobileSearchVisible && isMobileControlsOpen)));
+    requestAnimationFrame(updateHeaderOffsets);
+}
+
+function toggleMobileSearch(forceVisible = !isMobileSearchVisible) {
+    isMobileSearchVisible = !!forceVisible;
+    if (!isMobileSearchVisible) {
+        isMobileControlsOpen = false;
+    }
+    syncMobileHeaderState();
+    if (isMobileSearchVisible) {
+        document.getElementById('searchBox')?.focus();
+    }
+}
+
+function toggleMobileControls(forceOpen = !isMobileControlsOpen) {
+    if (!mobileHeaderMediaQuery.matches) return;
+    if (!isMobileSearchVisible) {
+        isMobileSearchVisible = true;
+    }
+    isMobileControlsOpen = !!forceOpen;
+    syncMobileHeaderState();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    syncMobileHeaderState();
+    mobileSearchTrigger?.addEventListener('click', () => toggleMobileSearch(true));
+    mobileControlsToggle?.addEventListener('click', () => toggleMobileControls());
+    window.addEventListener('resize', updateHeaderOffsets);
+    requestAnimationFrame(updateHeaderOffsets);
+});
+
+mobileHeaderMediaQuery.addEventListener('change', () => {
+    if (!mobileHeaderMediaQuery.matches) {
+        isMobileSearchVisible = false;
+        isMobileControlsOpen = false;
+    }
+    syncMobileHeaderState();
+});
+
+document.addEventListener('click', (event) => {
+    if (!mobileHeaderMediaQuery.matches || !isMobileSearchVisible || !headerEl) return;
+    if (!headerEl.contains(event.target)) {
+        toggleMobileSearch(false);
+    }
+});
+
 document.addEventListener('keydown', function (event) {
     if (event.key === 'Enter') {
         confirmSearchBtn.click();
+    }
+    if (event.key === 'Escape' && mobileHeaderMediaQuery.matches && isMobileSearchVisible) {
+        toggleMobileSearch(false);
     }
 });
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -17,27 +17,43 @@
 <body>
     <div id="chatToast" class="chat-toast" role="status" aria-live="polite"></div>
     <div class="container">
-        <div id="header">
-            <div class="header-main">
+        <div id="header" class="is-collapsed">
+            <button id="mobileSearchTrigger" class="header-icon-button mobile-search-trigger" type="button" aria-label="展开搜索" title="搜索">
+              <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="m20 20-3.5-3.5"></path>
+              </svg>
+            </button>
+            <div id="mobileSearchExpanded" class="mobile-search-expanded" aria-hidden="true">
               <div class="header-search-row">
                 <input type="text" id="searchBox" placeholder="请输入日期或聊天内容进行搜索...">
-                <button id="confirmSearch">搜索</button>
+                <button id="confirmSearch" class="header-icon-button" type="button" aria-label="执行搜索" title="搜索">
+                  <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="11" cy="11" r="7"></circle>
+                    <path d="m20 20-3.5-3.5"></path>
+                  </svg>
+                </button>
+                <button id="mobileControlsToggle" class="header-icon-button mobile-controls-toggle" type="button" aria-label="展开更多筛选" title="更多筛选">
+                  <svg viewBox="0 0 24 24" aria-hidden="true" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="m6 9 6 6 6-6"></path>
+                  </svg>
+                </button>
               </div>
-              <div class="header-filters">
-                <select id="chatSelect" class="select-component">
-                </select>
-                <select id="reactionSelect" class="select-component" title="表情排序">
-                </select>
-                <select id="repliesNumSelect" class="select-component" title="回复数排序">
-                  <option value="">按回复数排序</option>
-                  <option value="desc">回复数(高→低)</option>
-                </select>
+              <div id="mobileSearchPanel" class="mobile-search-panel" aria-hidden="true">
+                <div class="header-filters">
+                  <select id="chatSelect" class="select-component">
+                  </select>
+                  <select id="reactionSelect" class="select-component" title="表情排序">
+                  </select>
+                  <select id="repliesNumSelect" class="select-component" title="回复数排序">
+                    <option value="">按回复数排序</option>
+                    <option value="desc">回复数(高→低)</option>
+                  </select>
+                  <button id="downloadBrokenImages" type="button" title="下载该聊天所有缺失图片（按 10 张一批）">下载坏图</button>
+                  <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>
+                  <button id="exitReplies" class="hidden" type="button" title="返回聊天">返回</button>
+                </div>
               </div>
-            </div>
-            <div class="header-actions">
-              <button id="installChatApp" class="header-secondary" type="button" data-role="install-app" hidden disabled>安装 App</button>
-              <button id="downloadBrokenImages" title="下载该聊天所有缺失图片（按 10 张一批）">下载全部坏图</button>
-              <button id="exitReplies" class="hidden" title="返回聊天">返回</button>
             </div>
         </div>
         <div id="topLoader" class="top-loader hidden" aria-hidden="true">


### PR DESCRIPTION
## Summary
- stop relying on `me_id.txt`, `chats.json`, and `og_data.json` at runtime by moving me-id and OG cache into `data/app.db` and reading chats only from the DB
- add `scripts/migrate_legacy_storage_to_db.py` to import legacy me-id, chats, and OG cache into the app database
- redesign the mobile chat header so it starts as a transparent top-right search trigger, then expands leftward into the search row and an optional secondary controls panel
- add regression coverage for the DB storage helpers, migration script, and new mobile header structure/state hooks

## Test Plan
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python - <<'PY' ... client.get('/chat/test-chat') ... PY`

This addresses the legacy-file cleanup request and replaces the previous header behavior with the new transparent trigger interaction.