### PR TITLE
fix: follow-up fixes after PR #18 merge

### DIFF
--- a/scripts/migrate_legacy_storage_to_db.py
+++ b/scripts/migrate_legacy_storage_to_db.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
-from telegram_bot.db_utils import get_app_connection, set_me_id, set_og_cache, upsert_chat
-
-
 ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from telegram_bot.db_utils import get_app_connection, set_me_id, set_og_cache, upsert_chat
 
 
 def _load_json_file(path: Path) -> dict | list | None:

--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -44,6 +44,14 @@ def test_chat_js_controls_mobile_search_expand_state():
     assert "mobileSearchPanel.classList.toggle('is-open'" in script
 
 
+def test_chat_js_does_not_force_desktop_header_open_by_default():
+    script = _read("static/chat.js")
+
+    assert "mobileSearchExpanded.classList.add('is-visible');" not in script
+    assert "mobileSearchPanel.classList.add('is-open');" not in script
+    assert "mobileSearchTrigger.classList.remove('is-hidden');" not in script
+
+
 def test_chat_css_uses_transparent_default_header_and_left_expand_animation():
     css = _read("static/chat.css")
 
@@ -52,6 +60,19 @@ def test_chat_css_uses_transparent_default_header_and_left_expand_animation():
     assert '.mobile-search-expanded.is-visible {' in css
     assert 'transform-origin: right center;' in css
     assert 'translateX(0)' in css
+
+
+def test_chat_css_keeps_collapsed_trigger_right_aligned_on_mobile():
+    css = _read("static/chat.css")
+
+    assert re.search(r"body #header\s*\{[^}]*justify-content:\s*flex-end;", css, flags=re.S)
+
+
+def test_chat_css_gives_search_action_buttons_their_own_fixed_columns():
+    css = _read("static/chat.css")
+
+    assert re.search(r"#confirmSearch\s*,\s*#mobileControlsToggle\s*\{[^}]*width:\s*42px;", css, flags=re.S)
+    assert re.search(r"#confirmSearch\s*,\s*#mobileControlsToggle\s*\{[^}]*margin-left:\s*0;", css, flags=re.S)
 
 
 def test_management_template_has_mobile_chat_actions_grid():

--- a/static/chat.css
+++ b/static/chat.css
@@ -76,16 +76,13 @@ body {
     border-radius: .9375rem;
 }
 
-#confirmSearch {
-    margin-left: 10px;
-    background: #212121;
-    color: white;
-    border: none;
-    border-radius: .575rem;
-    cursor: pointer;
-    line-height: 16px;
-    width: 65px;
-    height: 37px;
+#confirmSearch,
+#mobileControlsToggle {
+    margin-left: 0;
+    width: 42px;
+    min-width: 42px;
+    height: 42px;
+    padding: 0;
 }
 
 #exitReplies {
@@ -619,7 +616,7 @@ body {
     }
 
     body #header {
-        justify-content: center;
+        justify-content: flex-end;
     }
 
     body #searchBox {
@@ -694,25 +691,53 @@ body {
     transform: translateX(-50%);
     width: min(1120px, calc(100% - 24px));
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    justify-content: flex-end;
     gap: 12px;
-    padding: 14px;
-    background: rgba(2, 6, 23, 0.78);
-    border: 1px solid var(--panel-border);
-    border-radius: 22px;
-    backdrop-filter: blur(18px);
-    box-shadow: var(--panel-shadow);
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    backdrop-filter: none;
+    box-shadow: none;
     top: max(10px, env(safe-area-inset-top));
 }
 
+#header.is-collapsed {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+}
+
 .mobile-search-trigger {
+    display: inline-flex;
+    flex: 0 0 auto;
+}
+
+.mobile-search-trigger.is-hidden {
     display: none;
 }
 
 .mobile-search-expanded {
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 0;
+    max-width: 100%;
+    opacity: 0;
+    overflow: hidden;
+    pointer-events: none;
+    transform: translateX(18px) scaleX(0.92);
+    transform-origin: right center;
+    transition: width 0.3s ease, opacity 0.22s ease, transform 0.3s ease;
+}
+
+.mobile-search-expanded.is-visible {
+    width: min(820px, calc(100vw - 96px));
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0) scaleX(1);
 }
 
 .mobile-search-panel,
@@ -724,8 +749,29 @@ body {
     width: 100%;
 }
 
+.header-filters {
+    background: rgba(2, 6, 23, 0.82);
+    border: 1px solid var(--panel-border);
+    border-radius: 18px;
+    padding: 12px;
+    box-shadow: var(--panel-shadow);
+}
+
 .mobile-search-panel {
-    margin-top: 10px;
+    max-height: 0;
+    margin-top: 8px;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(-6px);
+    pointer-events: none;
+    transition: max-height 0.28s ease, opacity 0.2s ease, transform 0.28s ease;
+}
+
+.mobile-search-panel.is-open {
+    max-height: 420px;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 #searchBox,
@@ -742,6 +788,11 @@ body {
     grid-template-columns: minmax(0, 1fr) 42px 42px;
     gap: 10px;
     align-items: center;
+    background: rgba(2, 6, 23, 0.82);
+    border: 1px solid var(--panel-border);
+    border-radius: 18px;
+    padding: 10px;
+    box-shadow: var(--panel-shadow);
 }
 
 #searchBox {

--- a/static/chat.js
+++ b/static/chat.js
@@ -1308,8 +1308,6 @@ const mobileSearchExpanded = document.getElementById('mobileSearchExpanded');
 const mobileSearchPanel = document.getElementById('mobileSearchPanel');
 const mobileControlsToggle = document.getElementById('mobileControlsToggle');
 const headerEl = document.getElementById('header');
-const mobileHeaderMediaQuery = window.matchMedia('(max-width: 768px)');
-
 let isMobileSearchVisible = false;
 let isMobileControlsOpen = false;
 
@@ -1322,18 +1320,6 @@ function updateHeaderOffsets() {
 
 function syncMobileHeaderState() {
     if (!headerEl || !mobileSearchTrigger || !mobileSearchExpanded || !mobileSearchPanel) return;
-
-    if (!mobileHeaderMediaQuery.matches) {
-        headerEl.classList.remove('is-collapsed');
-        mobileSearchTrigger.classList.remove('is-hidden');
-        mobileSearchExpanded.classList.add('is-visible');
-        mobileSearchPanel.classList.add('is-open');
-        mobileSearchExpanded.setAttribute('aria-hidden', 'false');
-        mobileSearchPanel.setAttribute('aria-hidden', 'false');
-        mobileControlsToggle?.classList.add('is-open');
-        requestAnimationFrame(updateHeaderOffsets);
-        return;
-    }
 
     headerEl.classList.toggle('is-collapsed', !isMobileSearchVisible);
     mobileSearchTrigger.classList.toggle('is-hidden', isMobileSearchVisible);
@@ -1357,7 +1343,6 @@ function toggleMobileSearch(forceVisible = !isMobileSearchVisible) {
 }
 
 function toggleMobileControls(forceOpen = !isMobileControlsOpen) {
-    if (!mobileHeaderMediaQuery.matches) return;
     if (!isMobileSearchVisible) {
         isMobileSearchVisible = true;
     }
@@ -1373,16 +1358,8 @@ document.addEventListener('DOMContentLoaded', () => {
     requestAnimationFrame(updateHeaderOffsets);
 });
 
-mobileHeaderMediaQuery.addEventListener('change', () => {
-    if (!mobileHeaderMediaQuery.matches) {
-        isMobileSearchVisible = false;
-        isMobileControlsOpen = false;
-    }
-    syncMobileHeaderState();
-});
-
 document.addEventListener('click', (event) => {
-    if (!mobileHeaderMediaQuery.matches || !isMobileSearchVisible || !headerEl) return;
+    if (!isMobileSearchVisible || !headerEl) return;
     if (!headerEl.contains(event.target)) {
         toggleMobileSearch(false);
     }
@@ -1392,7 +1369,7 @@ document.addEventListener('keydown', function (event) {
     if (event.key === 'Enter') {
         confirmSearchBtn.click();
     }
-    if (event.key === 'Escape' && mobileHeaderMediaQuery.matches && isMobileSearchVisible) {
+    if (event.key === 'Escape' && isMobileSearchVisible) {
         toggleMobileSearch(false);
     }
 });


### PR DESCRIPTION
## Summary
- keep the chat header collapsed by default on both desktop and mobile
- fix overlapping search action buttons and keep the trigger aligned to the right
- make `scripts/migrate_legacy_storage_to_db.py` runnable directly from the repo root

## Test Plan
- `python scripts/migrate_legacy_storage_to_db.py`
- `. .venv/bin/activate && PYTHONPATH=src pytest -q`

Follow-up to #18.