### PR TITLE
fix: stop mobile chat header icon buttons from overlapping

### DIFF
--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -75,6 +75,13 @@ def test_chat_css_gives_search_action_buttons_their_own_fixed_columns():
     assert re.search(r"#confirmSearch\s*,\s*#mobileControlsToggle\s*\{[^}]*margin-left:\s*0;", css, flags=re.S)
 
 
+def test_chat_css_does_not_force_mobile_search_icon_button_to_expand_to_88px():
+    css = _read("static/chat.css")
+
+    assert not re.search(r"body #confirmSearch\s*,\s*body #downloadBrokenImages", css, flags=re.S)
+    assert re.search(r"@media screen and \(max-width: 768px\)\s*\{.*?#confirmSearch\s*,\s*#mobileControlsToggle\s*\{[^}]*min-width:\s*42px;[^}]*max-width:\s*42px;", css, flags=re.S)
+
+
 def test_management_template_has_mobile_chat_actions_grid():
     template = _read("templates/index.html")
 

--- a/static/chat.css
+++ b/static/chat.css
@@ -625,7 +625,6 @@ body {
         margin-left: 0;
     }
 
-    body #confirmSearch,
     body #downloadBrokenImages,
     body #exitReplies,
     body .header-secondary {
@@ -981,5 +980,16 @@ body {
         width: 100%;
         min-width: 0;
         font-size: 13px;
+    }
+
+    #confirmSearch,
+    #mobileControlsToggle {
+        width: 42px;
+        min-width: 42px;
+        max-width: 42px;
+        height: 42px;
+        line-height: 1;
+        font-size: 0;
+        flex: 0 0 42px;
     }
 }


### PR DESCRIPTION
## Summary
- remove the inherited mobile `min-width: 88px` rule from the search icon button
- pin the mobile search and expand icon buttons to a strict 42px width so they cannot overlap
- add a regression test for the mobile icon-button sizing rules

## Test Plan
- `. .venv/bin/activate && PYTHONPATH=src pytest -q`

Follow-up to #19.