### PR TITLE
fix: remove chat background dimming overlay

### DIFF
--- a/src/test/test_ui_regressions.py
+++ b/src/test/test_ui_regressions.py
@@ -17,6 +17,14 @@ def test_chat_css_last_body_rule_keeps_bg_png_background():
     assert "url('resources/bg.png')" in body_rules[-1]
 
 
+def test_chat_css_last_body_rule_does_not_dim_bg_png_with_gradient_overlay():
+    css = _read("static/chat.css")
+    body_rules = re.findall(r"body\s*\{.*?\}", css, flags=re.S)
+
+    assert body_rules, "expected at least one body CSS rule"
+    assert "linear-gradient" not in body_rules[-1]
+
+
 def test_chat_template_has_collapsed_mobile_search_trigger_and_expand_panel():
     template = _read("templates/template.html")
 

--- a/static/chat.css
+++ b/static/chat.css
@@ -672,9 +672,7 @@ body {
 body {
     color: #e2e8f0;
     background-color: var(--app-bg);
-    background-image:
-      linear-gradient(180deg, rgba(2, 6, 23, 0.42), rgba(2, 6, 23, 0.68)),
-      url('resources/bg.png');
+    background-image: url('resources/bg.png');
     background-position: center top;
     background-repeat: repeat;
     padding-bottom: max(16px, env(safe-area-inset-bottom));


### PR DESCRIPTION
## Summary
- remove the dark gradient overlay from the chat page background
- keep `bg.png` as the only background image so it displays clearly
- add a regression test to prevent the overlay from coming back

## Test Plan
- `. .venv/bin/activate && PYTHONPATH=src pytest -q`

Follow-up to #20.